### PR TITLE
Feat/profile page

### DIFF
--- a/src/modules/atproto/infrastructure/services/FakeBlueskyProfileService.ts
+++ b/src/modules/atproto/infrastructure/services/FakeBlueskyProfileService.ts
@@ -16,7 +16,8 @@ export class FakeBlueskyProfileService implements IProfileService {
         id: userId,
         name: `Mock User`,
         handle: mockHandle,
-        avatarUrl: 'https://via.placeholder.com/150',
+        avatarUrl:
+          'https://cdn.bsky.app/img/avatar/plain/did:plc:rlknsba2qldjkicxsmni3vyn/bafkreid4nmxspygkftep5b3m2wlcm3xvnwefkswzej7dhipojjxylkzfby@jpeg',
         bio: 'This is a mock profile for testing purposes',
       };
 

--- a/src/webapp/app/(authenticated)/profile/[handle]/(withHeader)/layout.tsx
+++ b/src/webapp/app/(authenticated)/profile/[handle]/(withHeader)/layout.tsx
@@ -1,8 +1,9 @@
 import { ApiClient } from '@/api-client/ApiClient';
 import Header from '@/components/navigation/header/Header';
 import ProfileHeader from '@/features/profile/components/profileHeader/ProfileHeader';
+import ProfileTabs from '@/features/profile/components/profileTabs/ProfileTabs';
 import { getAccessTokenInServerComponent } from '@/services/auth';
-import { Button, Container, Stack, Text, Title } from '@mantine/core';
+import { Box, Button, Container, Stack, Title } from '@mantine/core';
 import type { Metadata } from 'next';
 import Link from 'next/link';
 import { Fragment } from 'react';
@@ -52,6 +53,17 @@ export default async function Layout(props: Props) {
     <Fragment>
       <Header />
       <ProfileHeader handle={handle} />
+      <Box
+        style={{
+          position: 'sticky',
+          top: 59,
+          zIndex: 101,
+        }}
+      >
+        <Container bg={'white'} px={'xs'} size={'xl'}>
+          <ProfileTabs handle={data.handle} />
+        </Container>
+      </Box>
       {props.children}
     </Fragment>
   );

--- a/src/webapp/app/(authenticated)/profile/[handle]/(withHeader)/layout.tsx
+++ b/src/webapp/app/(authenticated)/profile/[handle]/(withHeader)/layout.tsx
@@ -60,7 +60,7 @@ export default async function Layout(props: Props) {
           zIndex: 1,
         }}
       >
-        <Container bg={'white'} px={'xs'} size={'xl'}>
+        <Container bg={'white'} px={'xs'} mt={'md'} size={'xl'}>
           <ProfileTabs handle={data.handle} />
         </Container>
       </Box>

--- a/src/webapp/app/(authenticated)/profile/[handle]/(withHeader)/layout.tsx
+++ b/src/webapp/app/(authenticated)/profile/[handle]/(withHeader)/layout.tsx
@@ -57,7 +57,7 @@ export default async function Layout(props: Props) {
         style={{
           position: 'sticky',
           top: 59,
-          zIndex: 101,
+          zIndex: 1,
         }}
       >
         <Container bg={'white'} px={'xs'} size={'xl'}>

--- a/src/webapp/app/(authenticated)/profile/[handle]/(withHeader)/page.tsx
+++ b/src/webapp/app/(authenticated)/profile/[handle]/(withHeader)/page.tsx
@@ -1,3 +1,11 @@
-export default function Page() {
-  return <></>;
+import ProfileContainer from '@/features/profile/containers/profileContainer/ProfileContainer';
+
+interface Props {
+  params: Promise<{ handle: string }>;
+}
+
+export default async function Page(props: Props) {
+  const { handle } = await props.params;
+
+  return <ProfileContainer handle={handle} />;
 }

--- a/src/webapp/app/layout.tsx
+++ b/src/webapp/app/layout.tsx
@@ -1,5 +1,6 @@
 import { Analytics } from '@vercel/analytics/next';
 import type { Metadata } from 'next';
+import GlobalStyles from '@/styles/global.module.css';
 import { ColorSchemeScript, mantineHtmlProps } from '@mantine/core';
 import { Hanken_Grotesk } from 'next/font/google';
 import Providers from '@/providers';
@@ -30,7 +31,7 @@ export default function RootLayout({
       <head>
         <ColorSchemeScript />
       </head>
-      <body>
+      <body className={GlobalStyles.body}>
         <Providers>{children}</Providers>
         <Analytics />
       </body>

--- a/src/webapp/app/layout.tsx
+++ b/src/webapp/app/layout.tsx
@@ -31,7 +31,7 @@ export default function RootLayout({
       <head>
         <ColorSchemeScript />
       </head>
-      <body className={GlobalStyles.body}>
+      <body className={GlobalStyles.main}>
         <Providers>{children}</Providers>
         <Analytics />
       </body>

--- a/src/webapp/components/navigation/navbar/Navbar.tsx
+++ b/src/webapp/components/navigation/navbar/Navbar.tsx
@@ -30,7 +30,7 @@ export default function Navbar() {
   const { data: profile } = useMyProfile();
 
   return (
-    <AppShellNavbar px={'md'} pb={'md'} pt={'xs'}>
+    <AppShellNavbar px={'md'} pb={'md'} pt={'xs'} style={{ zIndex: 3 }}>
       <Group justify="space-between" ml={'sm'}>
         <Anchor component={Link} href={'/home'}>
           <Image src={SembleLogo.src} alt="Semble logo" w={20.84} h={28} />

--- a/src/webapp/components/navigation/navbar/Navbar.tsx
+++ b/src/webapp/components/navigation/navbar/Navbar.tsx
@@ -30,7 +30,7 @@ export default function Navbar() {
   const { data: profile } = useMyProfile();
 
   return (
-    <AppShellNavbar px={'md'} pb={'md'} pt={'xs'} style={{ zIndex: 3 }}>
+    <AppShellNavbar px={'xs'} pb={'md'} pt={'xs'} style={{ zIndex: 3 }}>
       <Group justify="space-between" ml={'sm'}>
         <Anchor component={Link} href={'/home'}>
           <Image src={SembleLogo.src} alt="Semble logo" w={20.84} h={28} />

--- a/src/webapp/features/cards/containers/myCardsContainer/MyCardsContainer.tsx
+++ b/src/webapp/features/cards/containers/myCardsContainer/MyCardsContainer.tsx
@@ -1,14 +1,6 @@
 'use client';
 
-import {
-  Container,
-  Grid,
-  Stack,
-  Title,
-  Button,
-  Text,
-  Center,
-} from '@mantine/core';
+import { Container, Grid, Stack, Button, Text, Center } from '@mantine/core';
 import useMyCards from '../../lib/queries/useMyCards';
 import UrlCard from '@/features/cards/components/urlCard/UrlCard';
 import { BiPlus } from 'react-icons/bi';
@@ -42,8 +34,6 @@ export default function MyCardsContainer() {
   return (
     <Container p="xs" size="xl">
       <Stack>
-        <Title order={1}>Cards</Title>
-
         {allCards.length > 0 ? (
           <Fragment>
             <Grid gutter="md">

--- a/src/webapp/features/cards/containers/myCardsContainer/MyCardsContainer.tsx
+++ b/src/webapp/features/cards/containers/myCardsContainer/MyCardsContainer.tsx
@@ -3,10 +3,11 @@
 import { Container, Grid, Stack, Button, Text, Center } from '@mantine/core';
 import useMyCards from '../../lib/queries/useMyCards';
 import UrlCard from '@/features/cards/components/urlCard/UrlCard';
-import AddCardDrawer from '../../components/addCardDrawer/AddCardDrawer';
 import MyCardsContainerError from './Error.MyCardsContainer';
 import MyCardsContainerSkeleton from './Skeleton.MyCardsContainer';
 import { Fragment, useState } from 'react';
+import ProfileEmptyTab from '@/features/profile/components/profileEmptyTab/ProfileEmptyTab';
+import { FaRegNoteSticky } from 'react-icons/fa6';
 
 export default function MyCardsContainer() {
   const {
@@ -18,8 +19,6 @@ export default function MyCardsContainer() {
     isPending,
   } = useMyCards();
 
-  const [showAddDrawer, setShowAddDrawer] = useState(false);
-
   const allCards = data?.pages.flatMap((page) => page.cards ?? []) ?? [];
 
   if (isPending) {
@@ -30,54 +29,47 @@ export default function MyCardsContainer() {
     return <MyCardsContainerError />;
   }
 
+  if (allCards.length === 0) {
+    return (
+      <Container px="xs" py={'xl'} size="xl">
+        <ProfileEmptyTab message="No cards" icon={FaRegNoteSticky} />
+      </Container>
+    );
+  }
+
   return (
     <Container p="xs" size="xl">
       <Stack>
-        {allCards.length > 0 ? (
-          <Fragment>
-            <Grid gutter="md">
-              {allCards.map((card) => (
-                <Grid.Col
-                  key={card.id}
-                  span={{ base: 12, xs: 6, sm: 4, lg: 3 }}
-                >
-                  <UrlCard
-                    id={card.id}
-                    url={card.url}
-                    cardContent={card.cardContent}
-                    note={card.note}
-                    collections={card.collections}
-                  />
-                </Grid.Col>
-              ))}
-            </Grid>
+        <Fragment>
+          <Grid gutter="md">
+            {allCards.map((card) => (
+              <Grid.Col key={card.id} span={{ base: 12, xs: 6, sm: 4, lg: 3 }}>
+                <UrlCard
+                  id={card.id}
+                  url={card.url}
+                  cardContent={card.cardContent}
+                  note={card.note}
+                  collections={card.collections}
+                />
+              </Grid.Col>
+            ))}
+          </Grid>
 
-            {hasNextPage && (
-              <Center>
-                <Button
-                  onClick={() => fetchNextPage()}
-                  disabled={isFetchingNextPage}
-                  loading={isFetchingNextPage}
-                  variant="light"
-                  color="gray"
-                  mt="md"
-                >
-                  Load More
-                </Button>
-              </Center>
-            )}
-          </Fragment>
-        ) : (
-          <Stack align="center" gap="xs">
-            <Text fz="h3" fw={600} c="gray">
-              No cards
-            </Text>
-            <AddCardDrawer
-              isOpen={showAddDrawer}
-              onClose={() => setShowAddDrawer(false)}
-            />
-          </Stack>
-        )}
+          {hasNextPage && (
+            <Center>
+              <Button
+                onClick={() => fetchNextPage()}
+                disabled={isFetchingNextPage}
+                loading={isFetchingNextPage}
+                variant="light"
+                color="gray"
+                mt="md"
+              >
+                Load More
+              </Button>
+            </Center>
+          )}
+        </Fragment>
       </Stack>
     </Container>
   );

--- a/src/webapp/features/cards/containers/myCardsContainer/MyCardsContainer.tsx
+++ b/src/webapp/features/cards/containers/myCardsContainer/MyCardsContainer.tsx
@@ -3,11 +3,10 @@
 import { Container, Grid, Stack, Button, Text, Center } from '@mantine/core';
 import useMyCards from '../../lib/queries/useMyCards';
 import UrlCard from '@/features/cards/components/urlCard/UrlCard';
-import { BiPlus } from 'react-icons/bi';
 import AddCardDrawer from '../../components/addCardDrawer/AddCardDrawer';
-import { Fragment, useState } from 'react';
 import MyCardsContainerError from './Error.MyCardsContainer';
 import MyCardsContainerSkeleton from './Skeleton.MyCardsContainer';
+import { Fragment, useState } from 'react';
 
 export default function MyCardsContainer() {
   const {
@@ -73,15 +72,6 @@ export default function MyCardsContainer() {
             <Text fz="h3" fw={600} c="gray">
               No cards
             </Text>
-            <Button
-              variant="light"
-              color="gray"
-              size="md"
-              rightSection={<BiPlus size={22} />}
-              onClick={() => setShowAddDrawer(true)}
-            >
-              Add your first card
-            </Button>
             <AddCardDrawer
               isOpen={showAddDrawer}
               onClose={() => setShowAddDrawer(false)}

--- a/src/webapp/features/cards/containers/myCardsContainer/Skeleton.MyCardsContainer.tsx
+++ b/src/webapp/features/cards/containers/myCardsContainer/Skeleton.MyCardsContainer.tsx
@@ -1,12 +1,10 @@
-import { Container, Grid, GridCol, Stack, Title } from '@mantine/core';
+import { Container, Grid, GridCol, Stack } from '@mantine/core';
 import UrlCardSkeleton from '../../components/urlCard/Skeleton.UrlCard';
 
 export default function MyCardsContainerSkeleton() {
   return (
     <Container p="xs" size="xl">
       <Stack>
-        <Title order={1}>Cards</Title>
-
         <Grid gutter="md">
           {Array.from({ length: 8 }).map((_, i) => (
             <GridCol key={i} span={{ base: 12, xs: 6, sm: 4, lg: 3 }}>

--- a/src/webapp/features/cards/lib/queries/useMyCards.tsx
+++ b/src/webapp/features/cards/lib/queries/useMyCards.tsx
@@ -12,7 +12,7 @@ export default function useMyCards(props?: Props) {
     () => getAccessToken(),
   );
 
-  const limit = props?.limit ?? 15;
+  const limit = props?.limit ?? 16;
 
   const query = useSuspenseInfiniteQuery({
     queryKey: ['my cards', limit],

--- a/src/webapp/features/collections/components/collectionCard/CollectionCard.tsx
+++ b/src/webapp/features/collections/components/collectionCard/CollectionCard.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import { getRelativeTime } from '@/lib/utils/time';
 import { Card, Group, Stack, Text } from '@mantine/core';
 import { useRouter } from 'next/navigation';

--- a/src/webapp/features/collections/containers/collectionsContainer/CollectionsContainer.tsx
+++ b/src/webapp/features/collections/containers/collectionsContainer/CollectionsContainer.tsx
@@ -4,7 +4,6 @@ import {
   Button,
   Container,
   Stack,
-  Title,
   Text,
   SimpleGrid,
   Center,
@@ -27,8 +26,6 @@ export default function CollectionsContainer() {
   return (
     <Container p="xs" size="xl">
       <Stack>
-        <Title order={1}>Collections</Title>
-
         {collections.length > 0 ? (
           <Stack>
             <SimpleGrid cols={{ base: 1, sm: 2, lg: 4 }} spacing="md">

--- a/src/webapp/features/collections/containers/collectionsContainer/CollectionsContainer.tsx
+++ b/src/webapp/features/collections/containers/collectionsContainer/CollectionsContainer.tsx
@@ -9,10 +9,9 @@ import {
   Center,
 } from '@mantine/core';
 import useCollections from '../../lib/queries/useCollections';
-import { BiPlus } from 'react-icons/bi';
 import CollectionCard from '../../components/collectionCard/CollectionCard';
-import { useState } from 'react';
 import CreateCollectionDrawer from '../../components/createCollectionDrawer/CreateCollectionDrawer';
+import { useState } from 'react';
 
 export default function CollectionsContainer() {
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
@@ -54,15 +53,6 @@ export default function CollectionsContainer() {
             <Text fz="h3" fw={600} c="gray">
               No collections
             </Text>
-            <Button
-              onClick={() => setIsDrawerOpen(true)}
-              variant="light"
-              color="gray"
-              size="md"
-              rightSection={<BiPlus size={22} />}
-            >
-              Create your first collection
-            </Button>
           </Stack>
         )}
       </Stack>

--- a/src/webapp/features/collections/containers/collectionsContainer/CollectionsContainer.tsx
+++ b/src/webapp/features/collections/containers/collectionsContainer/CollectionsContainer.tsx
@@ -12,6 +12,8 @@ import useCollections from '../../lib/queries/useCollections';
 import CollectionCard from '../../components/collectionCard/CollectionCard';
 import CreateCollectionDrawer from '../../components/createCollectionDrawer/CreateCollectionDrawer';
 import { useState } from 'react';
+import ProfileEmptyTab from '@/features/profile/components/profileEmptyTab/ProfileEmptyTab';
+import { BiCollection } from 'react-icons/bi';
 
 export default function CollectionsContainer() {
   const { data, fetchNextPage, hasNextPage, isFetchingNextPage } =
@@ -22,39 +24,40 @@ export default function CollectionsContainer() {
   const collections =
     data?.pages.flatMap((page) => page.collections ?? []) ?? [];
 
+  if (collections.length === 0) {
+    return (
+      <Container px="xs" py={'xl'} size="xl">
+        <ProfileEmptyTab message="No collections" icon={BiCollection} />
+      </Container>
+    );
+  }
+
   return (
     <Container p="xs" size="xl">
       <Stack>
-        {collections.length > 0 ? (
-          <Stack>
-            <SimpleGrid cols={{ base: 1, sm: 2, lg: 4 }} spacing="md">
-              {collections.map((collection) => (
-                <CollectionCard key={collection.id} collection={collection} />
-              ))}
-            </SimpleGrid>
+        <Stack>
+          <SimpleGrid cols={{ base: 1, sm: 2, lg: 4 }} spacing="md">
+            {collections.map((collection) => (
+              <CollectionCard key={collection.id} collection={collection} />
+            ))}
+          </SimpleGrid>
 
-            {hasNextPage && (
-              <Center>
-                <Button
-                  onClick={() => fetchNextPage()}
-                  disabled={isFetchingNextPage}
-                  loading={isFetchingNextPage}
-                  variant="light"
-                  color="gray"
-                  mt="md"
-                >
-                  Load More
-                </Button>
-              </Center>
-            )}
-          </Stack>
-        ) : (
-          <Stack align="center" gap="xs">
-            <Text fz="h3" fw={600} c="gray">
-              No collections
-            </Text>
-          </Stack>
-        )}
+          {hasNextPage && (
+            <Center>
+              <Button
+                onClick={() => fetchNextPage()}
+                disabled={isFetchingNextPage}
+                loading={isFetchingNextPage}
+                variant="light"
+                color="gray"
+                mt="md"
+              >
+                Load More
+              </Button>
+            </Center>
+          )}
+        </Stack>
+        )
       </Stack>
 
       <CreateCollectionDrawer

--- a/src/webapp/features/collections/containers/collectionsContainer/Skeleton.CollectionsContainer.tsx
+++ b/src/webapp/features/collections/containers/collectionsContainer/Skeleton.CollectionsContainer.tsx
@@ -1,12 +1,10 @@
-import { Container, SimpleGrid, Stack, Title } from '@mantine/core';
+import { Container, SimpleGrid, Stack } from '@mantine/core';
 import CollectionCardSkeleton from '../../components/collectionCard/Skeleton.CollectionCard';
 
 export default function CollectionsContainerSkeleton() {
   return (
     <Container p="xs" size="xl">
       <Stack>
-        <Title order={1}>Collections</Title>
-
         <SimpleGrid cols={{ base: 1, sm: 2, lg: 4 }} spacing="md">
           {Array.from({ length: 4 }).map((_, i) => (
             <CollectionCardSkeleton key={i} />

--- a/src/webapp/features/profile/components/profileEmptyTab/ProfileEmptyTab.tsx
+++ b/src/webapp/features/profile/components/profileEmptyTab/ProfileEmptyTab.tsx
@@ -1,0 +1,24 @@
+import { Stack, Text, Box } from '@mantine/core';
+import { IconType } from 'react-icons/lib';
+
+interface Props {
+  message: string;
+  icon: IconType;
+  button?: React.ReactElement;
+}
+
+export default function ProfileEmptyTab(props: Props) {
+  return (
+    <Stack align="center" gap="xs">
+      <Stack gap={0} align="center">
+        <Box c={'gray'}>
+          <props.icon size={40} />
+        </Box>
+        <Text fz="lg" fw={600} c="gray">
+          {props.message}
+        </Text>
+      </Stack>
+      {props.button}
+    </Stack>
+  );
+}

--- a/src/webapp/features/profile/components/profileHeader/MinimalProfileHeader.tsx
+++ b/src/webapp/features/profile/components/profileHeader/MinimalProfileHeader.tsx
@@ -1,0 +1,30 @@
+import { Group, Avatar, Stack, Title, Text, Container } from '@mantine/core';
+
+interface Props {
+  avatarUrl?: string;
+  name: string;
+  handle: string;
+}
+
+export default function MinimalProfileHeader(props: Props) {
+  return (
+    <Container p={'xs'} size={'xl'} mx={0}>
+      <Group gap={'sm'}>
+        <Avatar
+          src={props.avatarUrl}
+          alt={`${props.name}'s avatar`}
+          size={'md'}
+        />
+
+        <Stack gap={0}>
+          <Title order={1} fz={'sm'}>
+            {props.name}
+          </Title>
+          <Text c="blue" fw={600} fz={'sm'}>
+            @{props.handle}
+          </Text>
+        </Stack>
+      </Group>
+    </Container>
+  );
+}

--- a/src/webapp/features/profile/components/profileHeader/MinimalProfileHeader.tsx
+++ b/src/webapp/features/profile/components/profileHeader/MinimalProfileHeader.tsx
@@ -8,7 +8,7 @@ interface Props {
 
 export default function MinimalProfileHeader(props: Props) {
   return (
-    <Container p={'xs'} size={'xl'} mx={0}>
+    <Container px={0} py={'xs'} size={'xl'} mx={0}>
       <Group gap={'sm'}>
         <Avatar
           src={props.avatarUrl}

--- a/src/webapp/features/profile/components/profileHeader/ProfileHeader.tsx
+++ b/src/webapp/features/profile/components/profileHeader/ProfileHeader.tsx
@@ -1,5 +1,5 @@
-import { ApiClient } from '@/api-client/ApiClient';
-import { getAccessTokenInServerComponent } from '@/services/auth';
+'use client';
+
 import {
   Container,
   Stack,
@@ -8,26 +8,44 @@ import {
   Text,
   Title,
   Button,
+  Box,
 } from '@mantine/core';
 import { FaBluesky } from 'react-icons/fa6';
 import ProfileTabs from '../profileTabs/ProfileTabs';
 import { truncateText } from '@/lib/utils/text';
+import useMyProfile from '../../lib/queries/useMyProfile';
+import { useWindowScroll } from '@mantine/hooks';
+import MinimalProfileHeader from './MinimalProfileHeader';
 
 interface Props {
   handle: string;
 }
 
-export default async function ProfileHeader(props: Props) {
-  const accessToken = await getAccessTokenInServerComponent();
+export default function ProfileHeader(props: Props) {
+  const { data } = useMyProfile();
+  const [{ y }] = useWindowScroll();
 
-  const apiClient = new ApiClient(
-    process.env.NEXT_PUBLIC_API_BASE_URL || 'http://localhost:3000',
-    () => accessToken,
-  );
-  const data = await apiClient.getMyProfile();
-
+  // profile header
   return (
-    <Container p={'xs'} size={'xl'}>
+    <Container bg={'white'} p={'xs'} size={'xl'}>
+      <Box
+        style={{
+          position: 'fixed',
+          top: 0,
+          width: '100%',
+          zIndex: 101,
+          transform: `translateY(${y > 150 ? '0' : '-100px'})`,
+          transition: 'transform 200ms ease',
+          backgroundColor: 'var(--mantine-color-body)',
+        }}
+      >
+        <MinimalProfileHeader
+          avatarUrl={data.avatarUrl}
+          name={data.name}
+          handle={data.handle}
+        />
+      </Box>
+
       <Stack gap={'xl'}>
         <Group justify="space-between" align="end">
           <Group gap={'lg'} align="end">
@@ -59,7 +77,6 @@ export default async function ProfileHeader(props: Props) {
             {truncateText(data.handle, 14)}
           </Button>
         </Group>
-        <ProfileTabs handle={data.handle} />
       </Stack>
     </Container>
   );

--- a/src/webapp/features/profile/components/profileHeader/ProfileHeader.tsx
+++ b/src/webapp/features/profile/components/profileHeader/ProfileHeader.tsx
@@ -8,8 +8,10 @@ import {
   Text,
   Title,
   Button,
+  ActionIcon,
 } from '@mantine/core';
 import { FaBluesky } from 'react-icons/fa6';
+import ProfileTabs from '../profileTabs/ProfileTabs';
 
 interface Props {
   handle: string;
@@ -47,16 +49,19 @@ export default async function ProfileHeader(props: Props) {
               {data.description && <Text>{data.description}</Text>}
             </Stack>
           </Group>
-          <Button
+          <ActionIcon
             component="a"
             href={`https://bsky.app/profile/${data.handle}`}
             target="_blank"
-            color="gray"
-            leftSection={<FaBluesky size={22} />}
+            size={'lg'}
+            radius={'xl'}
+            bg="gray.2"
+            c={'gray'}
           >
-            @{data.handle}
-          </Button>
+            <FaBluesky />
+          </ActionIcon>
         </Group>
+        <ProfileTabs handle={data.handle} />
       </Stack>
     </Container>
   );

--- a/src/webapp/features/profile/components/profileHeader/ProfileHeader.tsx
+++ b/src/webapp/features/profile/components/profileHeader/ProfileHeader.tsx
@@ -51,7 +51,7 @@ export default function ProfileHeader(props: Props) {
             <Avatar
               src={data.avatarUrl}
               alt={`${data.name}'s avatar`}
-              size={180}
+              size={'clamp(110px, 14vw, 180px)'}
               radius={'lg'}
             />
             <Stack gap={'sm'}>

--- a/src/webapp/features/profile/components/profileHeader/ProfileHeader.tsx
+++ b/src/webapp/features/profile/components/profileHeader/ProfileHeader.tsx
@@ -23,9 +23,8 @@ interface Props {
 export default function ProfileHeader(props: Props) {
   const { data } = useMyProfile();
   const [{ y: yScroll }] = useWindowScroll();
-  const HEADER_REVEAL_SCROLL_THRESHOLD = 190;
+  const HEADER_REVEAL_SCROLL_THRESHOLD = 140;
 
-  // profile header
   return (
     <Container bg={'white'} p={'xs'} size={'xl'}>
       <Box
@@ -35,7 +34,7 @@ export default function ProfileHeader(props: Props) {
           width: '100%',
           zIndex: 2,
           transform: `translateY(${yScroll > HEADER_REVEAL_SCROLL_THRESHOLD ? '0' : '-100px'})`,
-          transition: 'transform 200ms ease',
+          transition: 'transform 100ms ease',
           backgroundColor: 'var(--mantine-color-body)',
         }}
       >

--- a/src/webapp/features/profile/components/profileHeader/ProfileHeader.tsx
+++ b/src/webapp/features/profile/components/profileHeader/ProfileHeader.tsx
@@ -16,6 +16,7 @@ import useMyProfile from '../../lib/queries/useMyProfile';
 import { useWindowScroll } from '@mantine/hooks';
 import MinimalProfileHeader from './MinimalProfileHeader';
 
+// TODO: once we have profile endpoints, we'll use handle to fetch profile data
 interface Props {
   handle: string;
 }

--- a/src/webapp/features/profile/components/profileHeader/ProfileHeader.tsx
+++ b/src/webapp/features/profile/components/profileHeader/ProfileHeader.tsx
@@ -22,7 +22,8 @@ interface Props {
 
 export default function ProfileHeader(props: Props) {
   const { data } = useMyProfile();
-  const [{ y }] = useWindowScroll();
+  const [{ y: yScroll }] = useWindowScroll();
+  const HEADER_REVEAL_SCROLL_THRESHOLD = 190;
 
   // profile header
   return (
@@ -33,7 +34,7 @@ export default function ProfileHeader(props: Props) {
           top: 0,
           width: '100%',
           zIndex: 2,
-          transform: `translateY(${y > 150 ? '0' : '-100px'})`,
+          transform: `translateY(${yScroll > HEADER_REVEAL_SCROLL_THRESHOLD ? '0' : '-100px'})`,
           transition: 'transform 200ms ease',
           backgroundColor: 'var(--mantine-color-body)',
         }}

--- a/src/webapp/features/profile/components/profileHeader/ProfileHeader.tsx
+++ b/src/webapp/features/profile/components/profileHeader/ProfileHeader.tsx
@@ -8,10 +8,10 @@ import {
   Text,
   Title,
   Button,
-  ActionIcon,
 } from '@mantine/core';
 import { FaBluesky } from 'react-icons/fa6';
 import ProfileTabs from '../profileTabs/ProfileTabs';
+import { truncateText } from '@/lib/utils/text';
 
 interface Props {
   handle: string;
@@ -28,38 +28,38 @@ export default async function ProfileHeader(props: Props) {
 
   return (
     <Container p={'xs'} size={'xl'}>
-      <Stack>
-        <Group justify="space-between">
-          <Group>
+      <Stack gap={'xl'}>
+        <Group justify="space-between" align="end">
+          <Group gap={'lg'} align="end">
             <Avatar
               src={data.avatarUrl}
               alt={`${data.name}'s avatar`}
-              size={'xl'}
+              size={180}
               radius={'lg'}
             />
             <Stack gap={'sm'}>
-              <Group>
-                <Title order={1} fz={'h4'}>
+              <Stack gap={0}>
+                <Title order={1} fz={'h2'}>
                   {data.name}
                 </Title>
-                <Text c="blue" fw={600} fz={'h4'}>
-                  {data.handle}
+                <Text c="blue" fw={600} fz={'xl'}>
+                  @{data.handle}
                 </Text>
-              </Group>
+              </Stack>
               {data.description && <Text>{data.description}</Text>}
             </Stack>
           </Group>
-          <ActionIcon
+          <Button
             component="a"
             href={`https://bsky.app/profile/${data.handle}`}
             target="_blank"
-            size={'lg'}
             radius={'xl'}
             bg="gray.2"
             c={'gray'}
+            leftSection={<FaBluesky />}
           >
-            <FaBluesky />
-          </ActionIcon>
+            {truncateText(data.handle, 14)}
+          </Button>
         </Group>
         <ProfileTabs handle={data.handle} />
       </Stack>

--- a/src/webapp/features/profile/components/profileHeader/ProfileHeader.tsx
+++ b/src/webapp/features/profile/components/profileHeader/ProfileHeader.tsx
@@ -51,13 +51,15 @@ export default function ProfileHeader(props: Props) {
             <Avatar
               src={data.avatarUrl}
               alt={`${data.name}'s avatar`}
-              size={'clamp(110px, 14vw, 180px)'}
+              size={'clamp(95px, 14vw, 180px)'}
               radius={'lg'}
             />
             <Stack gap={'sm'}>
               <Stack gap={0}>
-                <Title order={1}>{data.name}</Title>
-                <Text c="blue" fw={600} fz={'xl'}>
+                <Title order={1} fz={{ base: 'h2', md: 'h1' }}>
+                  {data.name}
+                </Title>
+                <Text c="blue" fw={600} fz={{ base: 'lg', md: 'xl' }}>
                   @{data.handle}
                 </Text>
               </Stack>

--- a/src/webapp/features/profile/components/profileHeader/ProfileHeader.tsx
+++ b/src/webapp/features/profile/components/profileHeader/ProfileHeader.tsx
@@ -11,7 +11,6 @@ import {
   Box,
 } from '@mantine/core';
 import { FaBluesky } from 'react-icons/fa6';
-import ProfileTabs from '../profileTabs/ProfileTabs';
 import { truncateText } from '@/lib/utils/text';
 import useMyProfile from '../../lib/queries/useMyProfile';
 import { useWindowScroll } from '@mantine/hooks';
@@ -33,7 +32,7 @@ export default function ProfileHeader(props: Props) {
           position: 'fixed',
           top: 0,
           width: '100%',
-          zIndex: 101,
+          zIndex: 2,
           transform: `translateY(${y > 150 ? '0' : '-100px'})`,
           transition: 'transform 200ms ease',
           backgroundColor: 'var(--mantine-color-body)',

--- a/src/webapp/features/profile/components/profileHeader/ProfileHeader.tsx
+++ b/src/webapp/features/profile/components/profileHeader/ProfileHeader.tsx
@@ -39,9 +39,7 @@ export default async function ProfileHeader(props: Props) {
             />
             <Stack gap={'sm'}>
               <Stack gap={0}>
-                <Title order={1} fz={'h2'}>
-                  {data.name}
-                </Title>
+                <Title order={1}>{data.name}</Title>
                 <Text c="blue" fw={600} fz={'xl'}>
                   @{data.handle}
                 </Text>

--- a/src/webapp/features/profile/components/profileMenu/ProfileMenu.tsx
+++ b/src/webapp/features/profile/components/profileMenu/ProfileMenu.tsx
@@ -60,7 +60,7 @@ export default function ProfileMenu() {
         <Menu.Dropdown>
           <Menu.Item component={Link} href={`/profile/${data.handle}`}>
             <Group gap={'xs'} wrap="nowrap">
-              <Avatar src={data.avatarUrl} size={48} />
+              <Avatar src={data.avatarUrl} size={'lg'} />
               <Stack gap={0}>
                 <Text fw={500} lineClamp={1} style={{ wordBreak: 'break-all' }}>
                   {data.name}

--- a/src/webapp/features/profile/components/profileTabs/ProfileTabs.tsx
+++ b/src/webapp/features/profile/components/profileTabs/ProfileTabs.tsx
@@ -2,32 +2,30 @@
 
 import { Tabs } from '@mantine/core';
 import TabItem from './TabItem';
-import { usePathname, useRouter } from 'next/navigation';
+import { usePathname } from 'next/navigation';
 
 interface Props {
   handle: string;
 }
 
 export default function ProfileTabs({ handle }: Props) {
-  const router = useRouter();
   const pathname = usePathname();
   const segment = pathname.split('/')[3];
   const currentTab = segment || 'profile'; // treat base route as 'profile'
-
-  const handleTabChange = (value: string | null) => {
-    if (!value || value === 'profile') {
-      router.push(`/profile/${handle}`);
-    } else {
-      router.push(`/profile/${handle}/${value}`);
-    }
-  };
+  const basePath = `/profile/${handle}`;
 
   return (
-    <Tabs value={currentTab} onChange={handleTabChange}>
+    <Tabs value={currentTab}>
       <Tabs.List>
-        <TabItem value="profile">Profile</TabItem>
-        <TabItem value="cards">Cards</TabItem>
-        <TabItem value="collections">Collections</TabItem>
+        <TabItem value="profile" href={basePath}>
+          Profile
+        </TabItem>
+        <TabItem value="cards" href={`${basePath}/cards`}>
+          Cards
+        </TabItem>
+        <TabItem value="collections" href={`${basePath}/collections`}>
+          Collections
+        </TabItem>
       </Tabs.List>
     </Tabs>
   );

--- a/src/webapp/features/profile/components/profileTabs/ProfileTabs.tsx
+++ b/src/webapp/features/profile/components/profileTabs/ProfileTabs.tsx
@@ -2,31 +2,32 @@
 
 import { Tabs } from '@mantine/core';
 import TabItem from './TabItem';
-import { usePathname } from 'next/navigation';
+import { usePathname, useRouter } from 'next/navigation';
 
 interface Props {
   handle: string;
 }
 
-export default function ProfileTabs(props: Props) {
+export default function ProfileTabs({ handle }: Props) {
+  const router = useRouter();
   const pathname = usePathname();
-  const currentTab = pathname.split('/').slice(3, 4).join('/') || 'profile';
+  const segment = pathname.split('/')[3];
+  const currentTab = segment || 'profile'; // treat base route as 'profile'
+
+  const handleTabChange = (value: string | null) => {
+    if (!value || value === 'profile') {
+      router.push(`/profile/${handle}`);
+    } else {
+      router.push(`/profile/${handle}/${value}`);
+    }
+  };
 
   return (
-    <Tabs defaultValue={'profile'} value={currentTab}>
+    <Tabs value={currentTab} onChange={handleTabChange}>
       <Tabs.List>
-        <TabItem value="profile" href={`/profile/${props.handle}`}>
-          Profile
-        </TabItem>
-        <TabItem value="cards" href={`/profile/${props.handle}/cards`}>
-          Cards
-        </TabItem>
-        <TabItem
-          value="collections"
-          href={`/profile/${props.handle}/collections`}
-        >
-          Collections
-        </TabItem>
+        <TabItem value="profile">Profile</TabItem>
+        <TabItem value="cards">Cards</TabItem>
+        <TabItem value="collections">Collections</TabItem>
       </Tabs.List>
     </Tabs>
   );

--- a/src/webapp/features/profile/components/profileTabs/ProfileTabs.tsx
+++ b/src/webapp/features/profile/components/profileTabs/ProfileTabs.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import { Tabs } from '@mantine/core';
+import TabItem from './TabItem';
+import { usePathname } from 'next/navigation';
+
+interface Props {
+  handle: string;
+}
+
+export default function ProfileTabs(props: Props) {
+  const pathname = usePathname();
+  const currentTab = pathname.split('/').slice(3, 4).join('/') || 'profile';
+
+  return (
+    <Tabs defaultValue={'profile'} value={currentTab}>
+      <Tabs.List>
+        <TabItem value="profile" href={`/profile/${props.handle}`}>
+          Profile
+        </TabItem>
+        <TabItem value="cards" href={`/profile/${props.handle}/cards`}>
+          Cards
+        </TabItem>
+        <TabItem
+          value="collections"
+          href={`/profile/${props.handle}/collections`}
+        >
+          Collections
+        </TabItem>
+      </Tabs.List>
+    </Tabs>
+  );
+}

--- a/src/webapp/features/profile/components/profileTabs/TabItem.module.css
+++ b/src/webapp/features/profile/components/profileTabs/TabItem.module.css
@@ -1,0 +1,11 @@
+.tab {
+  color: var(--mantine-color-dark-2); /* Inactive tab color */
+
+  @mixin hover {
+    color: var(--mantine-color-dark);
+  }
+}
+
+.tab[data-active] {
+  color: var(--mantine-color-dark); /* Active tab color */
+}

--- a/src/webapp/features/profile/components/profileTabs/TabItem.tsx
+++ b/src/webapp/features/profile/components/profileTabs/TabItem.tsx
@@ -1,24 +1,14 @@
 import { Tabs } from '@mantine/core';
-import { useRouter } from 'next/navigation';
 import classes from './TabItem.module.css';
 
 interface Props {
   value: string;
-  href: string;
   children: string;
 }
 
 export default function TabItem(props: Props) {
-  const router = useRouter();
-
   return (
-    <Tabs.Tab
-      value={props.value}
-      onClick={() => router.push(props.href)}
-      className={classes.tab}
-      color="dark"
-      fw={600}
-    >
+    <Tabs.Tab value={props.value} className={classes.tab} color="dark" fw={600}>
       {props.children}
     </Tabs.Tab>
   );

--- a/src/webapp/features/profile/components/profileTabs/TabItem.tsx
+++ b/src/webapp/features/profile/components/profileTabs/TabItem.tsx
@@ -1,0 +1,25 @@
+import { Tabs } from '@mantine/core';
+import { useRouter } from 'next/navigation';
+import classes from './TabItem.module.css';
+
+interface Props {
+  value: string;
+  href: string;
+  children: string;
+}
+
+export default function TabItem(props: Props) {
+  const router = useRouter();
+
+  return (
+    <Tabs.Tab
+      value={props.value}
+      onClick={() => router.push(props.href)}
+      className={classes.tab}
+      color="dark"
+      fw={600}
+    >
+      {props.children}
+    </Tabs.Tab>
+  );
+}

--- a/src/webapp/features/profile/components/profileTabs/TabItem.tsx
+++ b/src/webapp/features/profile/components/profileTabs/TabItem.tsx
@@ -11,12 +11,7 @@ interface Props {
 export default function TabItem(props: Props) {
   return (
     <Anchor component={Link} href={props.href} c={'dark'} underline="never">
-      <Tabs.Tab
-        value={props.value}
-        className={classes.tab}
-        color="dark"
-        fw={600}
-      >
+      <Tabs.Tab value={props.value} className={classes.tab} fw={600}>
         {props.children}
       </Tabs.Tab>
     </Anchor>

--- a/src/webapp/features/profile/components/profileTabs/TabItem.tsx
+++ b/src/webapp/features/profile/components/profileTabs/TabItem.tsx
@@ -1,15 +1,24 @@
-import { Tabs } from '@mantine/core';
+import { Anchor, Tabs } from '@mantine/core';
 import classes from './TabItem.module.css';
+import Link from 'next/link';
 
 interface Props {
   value: string;
+  href: string;
   children: string;
 }
 
 export default function TabItem(props: Props) {
   return (
-    <Tabs.Tab value={props.value} className={classes.tab} color="dark" fw={600}>
-      {props.children}
-    </Tabs.Tab>
+    <Anchor component={Link} href={props.href} c={'dark'} underline="never">
+      <Tabs.Tab
+        value={props.value}
+        className={classes.tab}
+        color="dark"
+        fw={600}
+      >
+        {props.children}
+      </Tabs.Tab>
+    </Anchor>
   );
 }

--- a/src/webapp/features/profile/containers/profileContainer/ProfileContainer.tsx
+++ b/src/webapp/features/profile/containers/profileContainer/ProfileContainer.tsx
@@ -1,51 +1,112 @@
-import {
-  Container,
-  Stack,
-  Group,
-  Avatar,
-  Text,
-  Title,
-  Button,
-} from '@mantine/core';
-import useMyProfile from '../../lib/queries/useMyProfile';
-import { FaBluesky } from 'react-icons/fa6';
+'use client';
 
-export default function ProfileContainer() {
-  const { data } = useMyProfile();
+import UrlCard from '@/features/cards/components/urlCard/UrlCard';
+import useMyCards from '@/features/cards/lib/queries/useMyCards';
+import CollectionCard from '@/features/collections/components/collectionCard/CollectionCard';
+import useCollections from '@/features/collections/lib/queries/useCollections';
+import {
+  Anchor,
+  Container,
+  Group,
+  SimpleGrid,
+  Stack,
+  Title,
+  Text,
+  Grid,
+} from '@mantine/core';
+import Link from 'next/link';
+
+interface Props {
+  handle: string;
+}
+
+export default function ProfileContainer(props: Props) {
+  // TODO: use profile endpoints to fetch profile information
+  // for now we'll use getMyProfile
+  const { data: collectionsData } = useCollections({ limit: 4 });
+  const { data: myCardsData } = useMyCards({ limit: 4 });
+
+  const collections =
+    collectionsData?.pages.flatMap((page) => page.collections) ?? [];
+  const cards = myCardsData?.pages.flatMap((page) => page.cards) ?? [];
 
   return (
     <Container p={'xs'} size={'xl'}>
       <Stack>
-        <Group justify="space-between">
-          <Group>
-            <Avatar
-              src={data.avatarUrl}
-              alt={`${data.name}'s avatar`}
-              size={'xl'}
-              radius={'lg'}
-            />
-            <Stack gap={'sm'}>
-              <Group>
-                <Title order={1} fz={'h4'}>
-                  {data.name}
-                </Title>
-                <Text c="blue" fw={600} fz={'h4'}>
-                  {data.handle}
+        <Stack gap={50}>
+          {/* Cards */}
+          <Stack>
+            <Group justify="space-between">
+              <Title order={2} fz={'h3'}>
+                Cards
+              </Title>
+              <Anchor
+                component={Link}
+                href={`/profile/${props.handle}/cards`}
+                c="blue"
+                fw={600}
+              >
+                View all
+              </Anchor>
+            </Group>
+
+            {cards.length > 0 ? (
+              <Grid gutter="md">
+                {cards.map((card) => (
+                  <Grid.Col
+                    key={card.id}
+                    span={{ base: 12, xs: 6, sm: 4, lg: 3 }}
+                  >
+                    <UrlCard
+                      id={card.id}
+                      url={card.url}
+                      cardContent={card.cardContent}
+                      note={card.note}
+                      collections={card.collections}
+                    />
+                  </Grid.Col>
+                ))}
+              </Grid>
+            ) : (
+              <Stack align="center" gap="xs">
+                <Text fz="h3" fw={600} c="gray">
+                  No cards
                 </Text>
-              </Group>
-              {data.description && <Text>{data.description}</Text>}
-            </Stack>
-          </Group>
-          <Button
-            component="a"
-            href={`https://bsky.app/profile/${data.handle}`}
-            target="_blank"
-            color="gray"
-            leftSection={<FaBluesky size={22} />}
-          >
-            @{data.handle}
-          </Button>
-        </Group>
+              </Stack>
+            )}
+          </Stack>
+
+          {/* Collections */}
+          <Stack>
+            <Group justify="space-between">
+              <Title order={2} fz={'h3'}>
+                Collections
+              </Title>
+              <Anchor
+                component={Link}
+                href={`/profile/${props.handle}/collections`}
+                c="blue"
+                fw={600}
+              >
+                View all
+              </Anchor>
+            </Group>
+
+            {collections.length > 0 ? (
+              <SimpleGrid cols={{ base: 1, sm: 2, lg: 4 }} spacing="md">
+                {collections.map((collection) => (
+                  <CollectionCard key={collection.id} collection={collection} />
+                ))}
+              </SimpleGrid>
+            ) : (
+              <Stack align="center" gap="xs">
+                <Text fz="h3" fw={600} c="gray">
+                  No collections
+                </Text>
+              </Stack>
+            )}
+          </Stack>
+        </Stack>
       </Stack>
     </Container>
   );

--- a/src/webapp/features/profile/containers/profileContainer/ProfileContainer.tsx
+++ b/src/webapp/features/profile/containers/profileContainer/ProfileContainer.tsx
@@ -15,6 +15,9 @@ import {
   Grid,
 } from '@mantine/core';
 import Link from 'next/link';
+import ProfileEmptyTab from '../../components/profileEmptyTab/ProfileEmptyTab';
+import { BiCollection } from 'react-icons/bi';
+import { FaRegNoteSticky } from 'react-icons/fa6';
 
 interface Props {
   handle: string;
@@ -68,11 +71,7 @@ export default function ProfileContainer(props: Props) {
                 ))}
               </Grid>
             ) : (
-              <Stack align="center" gap="xs">
-                <Text fz="h3" fw={600} c="gray">
-                  No cards
-                </Text>
-              </Stack>
+              <ProfileEmptyTab message="No cards" icon={FaRegNoteSticky} />
             )}
           </Stack>
 
@@ -99,11 +98,7 @@ export default function ProfileContainer(props: Props) {
                 ))}
               </SimpleGrid>
             ) : (
-              <Stack align="center" gap="xs">
-                <Text fz="h3" fw={600} c="gray">
-                  No collections
-                </Text>
-              </Stack>
+              <ProfileEmptyTab message="No collections" icon={BiCollection} />
             )}
           </Stack>
         </Stack>

--- a/src/webapp/features/profile/containers/profileContainer/Skeleton.ProfileContainer.tsx
+++ b/src/webapp/features/profile/containers/profileContainer/Skeleton.ProfileContainer.tsx
@@ -1,5 +1,55 @@
-import { Loader } from '@mantine/core';
+import UrlCardSkeleton from '@/features/cards/components/urlCard/Skeleton.UrlCard';
+import CollectionCardSkeleton from '@/features/collections/components/collectionCard/Skeleton.CollectionCard';
+import {
+  Container,
+  Grid,
+  GridCol,
+  Group,
+  SimpleGrid,
+  Skeleton,
+  Stack,
+  Title,
+} from '@mantine/core';
 
 export default function ProfileContainerSkeleton() {
-  return <Loader />;
+  return (
+    <Container p={'xs'} size={'xl'}>
+      <Stack gap={50}>
+        {/* Cards */}
+        <Stack>
+          <Group justify="space-between">
+            <Title order={2} fz={'h3'}>
+              Cards
+            </Title>
+            <Skeleton w={60} h={22} />
+          </Group>
+
+          <Grid gutter="md">
+            {Array.from({ length: 4 }).map((_, i) => (
+              <GridCol key={i} span={{ base: 12, xs: 6, sm: 4, lg: 3 }}>
+                <UrlCardSkeleton />
+              </GridCol>
+            ))}
+          </Grid>
+        </Stack>
+
+        {/* Collections */}
+        <Stack>
+          <Group justify="space-between">
+            <Title order={2} fz={'h3'}>
+              Collections
+            </Title>
+
+            <Skeleton w={60} h={22} />
+          </Group>
+
+          <SimpleGrid cols={{ base: 1, sm: 2, lg: 4 }} spacing="md">
+            {Array.from({ length: 4 }).map((_, i) => (
+              <CollectionCardSkeleton key={i} />
+            ))}
+          </SimpleGrid>
+        </Stack>
+      </Stack>
+    </Container>
+  );
 }

--- a/src/webapp/lib/utils/text.ts
+++ b/src/webapp/lib/utils/text.ts
@@ -1,0 +1,7 @@
+export const truncateText = (text: string, maxLength: number = 100) => {
+  if (typeof maxLength !== 'number' || text.length <= maxLength) {
+    return text;
+  }
+
+  return text.slice(0, maxLength) + '...';
+};

--- a/src/webapp/styles/global.module.css
+++ b/src/webapp/styles/global.module.css
@@ -1,0 +1,3 @@
+body {
+  overscroll-behavior: none;
+}

--- a/src/webapp/styles/global.module.css
+++ b/src/webapp/styles/global.module.css
@@ -1,3 +1,3 @@
-body {
+.main {
   overscroll-behavior: none;
 }

--- a/src/webapp/styles/theme.tsx
+++ b/src/webapp/styles/theme.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import TabItem from '@/features/profile/components/profileTabs/TabItem';
 import {
   Avatar,
   Button,
@@ -9,6 +10,7 @@ import {
   Modal,
   NavLink,
   Spoiler,
+  TabsTab,
 } from '@mantine/core';
 
 export const theme = createTheme({
@@ -109,6 +111,12 @@ export const theme = createTheme({
           color: 'gray',
           fontWeight: 600,
         },
+      },
+    }),
+    TabsTab: TabsTab.extend({
+      defaultProps: {
+        fw: 500,
+        fz: 'md',
       },
     }),
   },

--- a/src/webapp/styles/theme.tsx
+++ b/src/webapp/styles/theme.tsx
@@ -87,6 +87,17 @@ export const theme = createTheme({
       defaultProps: {
         radius: 'md',
       },
+      vars: (_, props) => {
+        if (props.size === 'xxl') {
+          return {
+            root: {
+              '--avatar-size': '120px',
+            },
+          };
+        }
+
+        return { root: {} };
+      },
     }),
     MenuItem: MenuItem.extend({
       defaultProps: {

--- a/src/webapp/styles/theme.tsx
+++ b/src/webapp/styles/theme.tsx
@@ -1,11 +1,10 @@
 'use client';
 
-import TabItem from '@/features/profile/components/profileTabs/TabItem';
 import {
+  createTheme,
   Avatar,
   Button,
   CheckboxIndicator,
-  createTheme,
   MenuItem,
   Modal,
   NavLink,

--- a/src/webapp/styles/theme.tsx
+++ b/src/webapp/styles/theme.tsx
@@ -86,17 +86,6 @@ export const theme = createTheme({
       defaultProps: {
         radius: 'md',
       },
-      vars: (_, props) => {
-        if (props.size === 'xxl') {
-          return {
-            root: {
-              '--avatar-size': '120px',
-            },
-          };
-        }
-
-        return { root: {} };
-      },
     }),
     MenuItem: MenuItem.extend({
       defaultProps: {


### PR DESCRIPTION
This updates the profile page with a new design:
- Profile header
- Profile tabs (profile/summary, cards, collections) + containers
- Empty profile tab states (ex. no cards)


Additional changes:
- Remove custom avatar size on profile menu and use existing sizes
- Use Cosmik testing account avatar for mock account
- Disable default overscroll behaviour 