### PR TITLE
Share target additional Android support

### DIFF
--- a/src/webapp/app/manifest.ts
+++ b/src/webapp/app/manifest.ts
@@ -35,6 +35,8 @@ export default function manifest(): MetadataRoute.Manifest {
       method: 'GET',
       params: {
         url: 'addUrl',
+        text: 'addText',
+        title: 'addTitle',
       },
     },
   };

--- a/src/webapp/features/composer/components/composerDrawer/ComposerDrawer.tsx
+++ b/src/webapp/features/composer/components/composerDrawer/ComposerDrawer.tsx
@@ -12,7 +12,12 @@ export default function ComposerDrawer() {
   const isNavOpen = isDesktop ? desktopOpened : mobileOpened;
   const shouldShowFab = !isNavOpen;
   const [opened, setOpened] = useState(false);
-  const addUrl = useSearchParams().get('addUrl');
+
+  // share_target support. on android could be any of these.
+  const shareUrl = useSearchParams().get('addUrl');
+  const shareText = useSearchParams().get('addText');
+  const shareTitle = useSearchParams().get('addTitle');
+  const addUrl = shareUrl || shareText || shareTitle;
 
   useEffect(() => {
     if (addUrl) {


### PR DESCRIPTION
Improves #434 / #388.

Android system limitations don't allow it to share `url`s; urls are as passed as `text` or sometimes `title`. Add these as additional fallbacks to get urls from.