### PR TITLE
fix: don't interpolate null for no cards placeholder message

### DIFF
--- a/src/webapp/features/cards/containers/cardsContainerContent/CardsContainerContent.tsx
+++ b/src/webapp/features/cards/containers/cardsContainerContent/CardsContainerContent.tsx
@@ -59,7 +59,7 @@ export default function CardsContainerContent(props: Props) {
     return (
       <Container px="xs" py={'xl'} size="xl">
         <ProfileEmptyTab
-          message={`No ${selectedUrlType} cards`}
+          message={selectedUrlType ? `No ${selectedUrlType} cards` : 'No cards'}
           icon={FaRegNoteSticky}
         />
       </Container>


### PR DESCRIPTION
intended to fix "No null cards" in screenshot

![empty cards container screenshot](https://github.com/user-attachments/assets/764e1a01-cea1-4d96-911c-4d32afcae75f)
