### PR TITLE
feat: add character counter to note input fields

### DIFF
--- a/src/webapp/features/cards/components/addCardActions/AddCardActions.tsx
+++ b/src/webapp/features/cards/components/addCardActions/AddCardActions.tsx
@@ -26,7 +26,7 @@ export default function AddCardActions(props: Props) {
   const [showDeleteWarning, setShowDeleteWarning] = useState(false);
   const [noteMode, setNoteMode] = useState(false);
   const [note, setNote] = useState(props.note);
-  const maxNoteLength = 500;
+  const MAX_NOTE_LENGTH = 500;
 
   const removeNote = useRemoveCardFromLibrary();
 
@@ -62,7 +62,7 @@ export default function AddCardActions(props: Props) {
                 Your note
               </Input.Label>
               <Text aria-hidden>
-                {note?.length ?? 0} / {maxNoteLength}
+                {note?.length ?? 0} / {MAX_NOTE_LENGTH}
               </Text>
             </Flex>
 
@@ -77,7 +77,7 @@ export default function AddCardActions(props: Props) {
               onChange={(e) => setNote(e.currentTarget.value)}
             />
             <VisuallyHidden id="note-char-remaining" aria-live="polite">
-              {`${maxNoteLength - (note?.length ?? 0)} characters remaining`}
+              {`${MAX_NOTE_LENGTH - (note?.length ?? 0)} characters remaining`}
             </VisuallyHidden>
           </Stack>
           <Group gap={'xs'} grow>

--- a/src/webapp/features/cards/components/addCardDrawer/AddCardDrawer.tsx
+++ b/src/webapp/features/cards/components/addCardDrawer/AddCardDrawer.tsx
@@ -60,7 +60,7 @@ export default function AddCardDrawer(props: Props) {
     },
   });
 
-  const maxNoteLength = 500;
+  const MAX_NOTE_LENGTH = 500;
   const { note } = form.getValues();
 
   useEffect(() => {
@@ -137,7 +137,7 @@ export default function AddCardDrawer(props: Props) {
                       Note
                     </Input.Label>
                     <Text aria-hidden>
-                      {note?.length ?? 0} / {maxNoteLength}
+                      {form.getValues().note.length} / {MAX_NOTE_LENGTH}
                     </Text>
                   </Flex>
 
@@ -147,13 +147,13 @@ export default function AddCardDrawer(props: Props) {
                     variant="filled"
                     size="md"
                     rows={3}
-                    maxLength={maxNoteLength}
+                    maxLength={MAX_NOTE_LENGTH}
                     aria-describedby="note-char-remaining"
                     key={form.key('note')}
                     {...form.getInputProps('note')}
                   />
                   <VisuallyHidden id="note-char-remaining" aria-live="polite">
-                    {`${maxNoteLength - (note?.length ?? 0)} characters remaining`}
+                    {`${MAX_NOTE_LENGTH - form.getValues().note.length} characters remaining`}
                   </VisuallyHidden>
                 </Stack>
               </Stack>

--- a/src/webapp/features/notes/components/noteCardModal/NoteCardModalContent.tsx
+++ b/src/webapp/features/notes/components/noteCardModal/NoteCardModalContent.tsx
@@ -36,7 +36,7 @@ export default function NoteCardModalContent(props: Props) {
   const [note, setNote] = useState(isMyCard ? props.note?.text : '');
   const [editMode, setEditMode] = useState(false);
   const [showDeleteWarning, setShowDeleteWarning] = useState(false);
-  const maxNoteLength = 500;
+  const MAX_NOTE_LENGTH = 500;
 
   const removeNote = useRemoveCardFromLibrary();
   const updateNote = useUpdateNote();
@@ -96,7 +96,7 @@ export default function NoteCardModalContent(props: Props) {
               Your note
             </Input.Label>
             <Text aria-hidden>
-              {note?.length ?? 0} / {maxNoteLength}
+              {note?.length ?? 0} / {MAX_NOTE_LENGTH}
             </Text>
           </Flex>
 
@@ -108,12 +108,12 @@ export default function NoteCardModalContent(props: Props) {
             autosize
             minRows={3}
             maxRows={8}
-            maxLength={maxNoteLength}
+            maxLength={MAX_NOTE_LENGTH}
             value={note}
             onChange={(e) => setNote(e.currentTarget.value)}
           />
           <VisuallyHidden id="note-char-remaining" aria-live="polite">
-            {`${maxNoteLength - (note?.length ?? 0)} characters remaining`}
+            {`${MAX_NOTE_LENGTH - (note?.length ?? 0)} characters remaining`}
           </VisuallyHidden>
         </Stack>
 


### PR DESCRIPTION
## 📝 Description
Adds a character counter to the Note TextAreas in `AddCardAction.tsx`, `NoteCardModalContent.tsx`, and `AddCardDrawer.tsx`. 

## 🔗 Related Issue
Based on #536 and the discussion weswalla and I had on Discord.

## 🛠️ Type of Change
Check all that apply:
- [x] ✨ New feature (non-breaking change which adds functionality)

## 🧪 How Has This Been Tested?
Please describe the tests that you ran to verify your changes. 
- [x] **Ran unit tests with npm run test:unit**
- [x] **Verified manually on Chrome/Firefox**

## 📸 Screenshots (if applicable)
| Before | After |
| :--- | :--- |
| <img width="443" height="761" alt="image" src="https://github.com/user-attachments/assets/79a3db2b-93cc-47dc-9891-c622b1a22330" /> | <img width="443" height="761" alt="image" src="https://github.com/user-attachments/assets/97628b0f-084c-4328-9e3f-38d150c91c55" /> |
| <img width="445" height="259" alt="image" src="https://github.com/user-attachments/assets/23637d73-3447-4646-ac5c-d2db7b0ce9b2" /> | <img width="453" height="255" alt="image" src="https://github.com/user-attachments/assets/4b1da022-a33a-483a-ac86-50b9fdca9749" /> |
| <img width="844" height="485" alt="image" src="https://github.com/user-attachments/assets/f8d3b521-a5ea-401e-81a9-3e8a66632156" /> | <img width="797" height="490" alt="image" src="https://github.com/user-attachments/assets/c13ab78f-c510-453c-a258-391519beecfc" /> |

## ✅ Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings