### PR TITLE
chore: migrate to nextjs 16.2.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1126,6 +1126,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.4.tgz",
       "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -1783,6 +1784,7 @@
           "url": "https://opencollective.com/csstools"
         }
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -1805,6 +1807,7 @@
           "url": "https://opencollective.com/csstools"
         }
       ],
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1827,9 +1830,11 @@
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.6.0.tgz",
-      "integrity": "sha512-obtUmAHTMjll499P+D9A3axeJFlhdjOWdKUNs/U6QIGT7V5RjcUW1xToAzjvmgTSQhDbYn/NwfTRoJcQ2rNBxA==",
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
+      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "dev": true,
+      "license": "MIT",
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
@@ -2673,10 +2678,11 @@
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.0.tgz",
-      "integrity": "sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g==",
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+      "integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "eslint-visitor-keys": "^3.4.3"
       },
@@ -2700,14 +2706,15 @@
       }
     },
     "node_modules/@eslint/config-array": {
-      "version": "0.21.1",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.1.tgz",
-      "integrity": "sha512-aw1gNayWpdI/jSYVgzN5pL0cfzU02GT3NBpeT/DXbx1/1x7ZKxFPd9bwrzygx/qiwIQiJ1sw/zD8qY/kRvlGHA==",
+      "version": "0.21.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
+      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@eslint/object-schema": "^2.1.7",
         "debug": "^4.3.1",
-        "minimatch": "^3.1.2"
+        "minimatch": "^3.1.5"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2738,22 +2745,24 @@
       }
     },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.1.tgz",
-      "integrity": "sha512-csZAzkNhsgwb0I/UAV6/RGFTbiakPCf0ZrGmrIxQpYvGZ00PhTkSnyKNolphgIvmnJeGw6rcGVEXfTzUnFuEvw==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
+      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^0.16.0"
+        "@eslint/core": "^0.17.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "node_modules/@eslint/core": {
-      "version": "0.16.0",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.16.0.tgz",
-      "integrity": "sha512-nmC8/totwobIiFcGkDza3GIKfAw1+hLiYVrh3I1nIomQ8PEr5cxg34jnkmGawul/ep52wGRAcyeDCNtWKSOj4Q==",
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
+      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "@types/json-schema": "^7.0.15"
       },
@@ -2762,19 +2771,20 @@
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.1.tgz",
-      "integrity": "sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ==",
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.5.tgz",
+      "integrity": "sha512-4IlJx0X0qftVsN5E+/vGujTRIFtwuLbNsVUe7TO6zYPDR1O6nFwvwhIKEKSrl6dZchmYBITazxKoUYOjdtjlRg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "ajv": "^6.12.4",
+        "ajv": "^6.14.0",
         "debug": "^4.3.2",
         "espree": "^10.0.1",
         "globals": "^14.0.0",
         "ignore": "^5.2.0",
         "import-fresh": "^3.2.1",
-        "js-yaml": "^4.1.0",
-        "minimatch": "^3.1.2",
+        "js-yaml": "^4.1.1",
+        "minimatch": "^3.1.5",
         "strip-json-comments": "^3.1.1"
       },
       "engines": {
@@ -2800,6 +2810,7 @@
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
       "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 4"
       }
@@ -2818,10 +2829,11 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.38.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.38.0.tgz",
-      "integrity": "sha512-UZ1VpFvXf9J06YG9xQBdnzU+kthors6KjhMAl6f4gH4usHyh31rUf2DLGInT8RFYIReYXNSydgPY0V2LuWgl7A==",
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
+      "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -2834,17 +2846,19 @@
       "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
       "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
       "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.0.tgz",
-      "integrity": "sha512-sB5uyeq+dwCWyPi31B2gQlVlo+j5brPlWx4yZBrEaRo/nhdDE8Xke1gsGgtiBdaBTxuTkceLVuVt/pclrasb0A==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
+      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^0.16.0",
+        "@eslint/core": "^0.17.0",
         "levn": "^0.4.1"
       },
       "engines": {
@@ -3087,45 +3101,6 @@
         "node": ">=18.18.0"
       }
     },
-    "node_modules/@humanwhocodes/config-array": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.13.0.tgz",
-      "integrity": "sha512-DZLEEqFWQFiyK6h5YIeynKx7JlvCYWL0cImfSRXZ9l4Sg2efkFGTuFf6vzXjK1cq6IYkU+Eg/JizXw+TD2vRNw==",
-      "deprecated": "Use @eslint/config-array instead",
-      "dev": true,
-      "dependencies": {
-        "@humanwhocodes/object-schema": "^2.0.3",
-        "debug": "^4.3.1",
-        "minimatch": "^3.0.5"
-      },
-      "engines": {
-        "node": ">=10.10.0"
-      }
-    },
-    "node_modules/@humanwhocodes/config-array/node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/@humanwhocodes/config-array/node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/@humanwhocodes/module-importer": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
@@ -3138,13 +3113,6 @@
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
       }
-    },
-    "node_modules/@humanwhocodes/object-schema": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.3.tgz",
-      "integrity": "sha512-93zYdMES/c1D69yZiKDBj0V24vqNzB/koF26KPaagAfd3P/4gUlh3Dys5ogAK+Exi9QyzlD8x/08Zt7wIKcDcA==",
-      "deprecated": "Use @eslint/object-schema instead",
-      "dev": true
     },
     "node_modules/@humanwhocodes/retry": {
       "version": "0.4.3",
@@ -3169,12 +3137,14 @@
       }
     },
     "node_modules/@img/sharp-darwin-arm64": {
-      "version": "0.34.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.4.tgz",
-      "integrity": "sha512-sitdlPzDVyvmINUdJle3TNHl+AG9QcwiAMsXmccqsCOMZNIdW2/7S26w0LyU8euiLVzFBL3dXPwVCq/ODnf2vA==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
       "cpu": [
         "arm64"
       ],
+      "dev": true,
+      "license": "Apache-2.0",
       "optional": true,
       "os": [
         "darwin"
@@ -3186,16 +3156,18 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-arm64": "1.2.3"
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
       }
     },
     "node_modules/@img/sharp-darwin-x64": {
-      "version": "0.34.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.4.tgz",
-      "integrity": "sha512-rZheupWIoa3+SOdF/IcUe1ah4ZDpKBGWcsPX6MT0lYniH9micvIU7HQkYTfrx5Xi8u+YqwLtxC/3vl8TQN6rMg==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
       "cpu": [
         "x64"
       ],
+      "dev": true,
+      "license": "Apache-2.0",
       "optional": true,
       "os": [
         "darwin"
@@ -3207,16 +3179,18 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-x64": "1.2.3"
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
       }
     },
     "node_modules/@img/sharp-libvips-darwin-arm64": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.3.tgz",
-      "integrity": "sha512-QzWAKo7kpHxbuHqUC28DZ9pIKpSi2ts2OJnoIGI26+HMgq92ZZ4vk8iJd4XsxN+tYfNJxzH6W62X5eTcsBymHw==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
       "cpu": [
         "arm64"
       ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
         "darwin"
@@ -3226,12 +3200,14 @@
       }
     },
     "node_modules/@img/sharp-libvips-darwin-x64": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.3.tgz",
-      "integrity": "sha512-Ju+g2xn1E2AKO6YBhxjj+ACcsPQRHT0bhpglxcEf+3uyPY+/gL8veniKoo96335ZaPo03bdDXMv0t+BBFAbmRA==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
       "cpu": [
         "x64"
       ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
         "darwin"
@@ -3241,12 +3217,14 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.3.tgz",
-      "integrity": "sha512-x1uE93lyP6wEwGvgAIV0gP6zmaL/a0tGzJs/BIDDG0zeBhMnuUPm7ptxGhUbcGs4okDJrk4nxgrmxpib9g6HpA==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
       "cpu": [
         "arm"
       ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
         "linux"
@@ -3256,12 +3234,14 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm64": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.3.tgz",
-      "integrity": "sha512-I4RxkXU90cpufazhGPyVujYwfIm9Nk1QDEmiIsaPwdnm013F7RIceaCc87kAH+oUB1ezqEvC6ga4m7MSlqsJvQ==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
       "cpu": [
         "arm64"
       ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
         "linux"
@@ -3271,12 +3251,31 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-ppc64": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.3.tgz",
-      "integrity": "sha512-Y2T7IsQvJLMCBM+pmPbM3bKT/yYJvVtLJGfCs4Sp95SjvnFIjynbjzsa7dY1fRJX45FTSfDksbTp6AGWudiyCg==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
         "linux"
@@ -3286,12 +3285,14 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-s390x": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.3.tgz",
-      "integrity": "sha512-RgWrs/gVU7f+K7P+KeHFaBAJlNkD1nIZuVXdQv6S+fNA6syCcoboNjsV2Pou7zNlVdNQoQUpQTk8SWDHUA3y/w==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
       "cpu": [
         "s390x"
       ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
         "linux"
@@ -3301,12 +3302,14 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-x64": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.3.tgz",
-      "integrity": "sha512-3JU7LmR85K6bBiRzSUc/Ff9JBVIFVvq6bomKE0e63UXGeRw2HPVEjoJke1Yx+iU4rL7/7kUjES4dZ/81Qjhyxg==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
       "cpu": [
         "x64"
       ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
         "linux"
@@ -3316,12 +3319,14 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.3.tgz",
-      "integrity": "sha512-F9q83RZ8yaCwENw1GieztSfj5msz7GGykG/BA+MOUefvER69K/ubgFHNeSyUu64amHIYKGDs4sRCMzXVj8sEyw==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
       "cpu": [
         "arm64"
       ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
         "linux"
@@ -3331,12 +3336,14 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-x64": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.3.tgz",
-      "integrity": "sha512-U5PUY5jbc45ANM6tSJpsgqmBF/VsL6LnxJmIf11kB7J5DctHgqm0SkuXzVWtIY90GnJxKnC/JT251TDnk1fu/g==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
       "cpu": [
         "x64"
       ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
         "linux"
@@ -3346,12 +3353,14 @@
       }
     },
     "node_modules/@img/sharp-linux-arm": {
-      "version": "0.34.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.4.tgz",
-      "integrity": "sha512-Xyam4mlqM0KkTHYVSuc6wXRmM7LGN0P12li03jAnZ3EJWZqj83+hi8Y9UxZUbxsgsK1qOEwg7O0Bc0LjqQVtxA==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
       "cpu": [
         "arm"
       ],
+      "dev": true,
+      "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
@@ -3363,16 +3372,18 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm": "1.2.3"
+        "@img/sharp-libvips-linux-arm": "1.2.4"
       }
     },
     "node_modules/@img/sharp-linux-arm64": {
-      "version": "0.34.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.4.tgz",
-      "integrity": "sha512-YXU1F/mN/Wu786tl72CyJjP/Ngl8mGHN1hST4BGl+hiW5jhCnV2uRVTNOcaYPs73NeT/H8Upm3y9582JVuZHrQ==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
       "cpu": [
         "arm64"
       ],
+      "dev": true,
+      "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
@@ -3384,16 +3395,18 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm64": "1.2.3"
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
       }
     },
     "node_modules/@img/sharp-linux-ppc64": {
-      "version": "0.34.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.4.tgz",
-      "integrity": "sha512-F4PDtF4Cy8L8hXA2p3TO6s4aDt93v+LKmpcYFLAVdkkD3hSxZzee0rh6/+94FpAynsuMpLX5h+LRsSG3rIciUQ==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
+      "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
@@ -3405,16 +3418,41 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-ppc64": "1.2.3"
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
       }
     },
     "node_modules/@img/sharp-linux-s390x": {
-      "version": "0.34.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.4.tgz",
-      "integrity": "sha512-qVrZKE9Bsnzy+myf7lFKvng6bQzhNUAYcVORq2P7bDlvmF6u2sCmK2KyEQEBdYk+u3T01pVsPrkj943T1aJAsw==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
       "cpu": [
         "s390x"
       ],
+      "dev": true,
+      "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
@@ -3426,16 +3464,18 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-s390x": "1.2.3"
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
       }
     },
     "node_modules/@img/sharp-linux-x64": {
-      "version": "0.34.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.4.tgz",
-      "integrity": "sha512-ZfGtcp2xS51iG79c6Vhw9CWqQC8l2Ot8dygxoDoIQPTat/Ov3qAa8qpxSrtAEAJW+UjTXc4yxCjNfxm4h6Xm2A==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
       "cpu": [
         "x64"
       ],
+      "dev": true,
+      "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
@@ -3447,16 +3487,18 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-x64": "1.2.3"
+        "@img/sharp-libvips-linux-x64": "1.2.4"
       }
     },
     "node_modules/@img/sharp-linuxmusl-arm64": {
-      "version": "0.34.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.4.tgz",
-      "integrity": "sha512-8hDVvW9eu4yHWnjaOOR8kHVrew1iIX+MUgwxSuH2XyYeNRtLUe4VNioSqbNkB7ZYQJj9rUTT4PyRscyk2PXFKA==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
       "cpu": [
         "arm64"
       ],
+      "dev": true,
+      "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
@@ -3468,16 +3510,18 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-arm64": "1.2.3"
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
       }
     },
     "node_modules/@img/sharp-linuxmusl-x64": {
-      "version": "0.34.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.4.tgz",
-      "integrity": "sha512-lU0aA5L8QTlfKjpDCEFOZsTYGn3AEiO6db8W5aQDxj0nQkVrZWmN3ZP9sYKWJdtq3PWPhUNlqehWyXpYDcI9Sg==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
       "cpu": [
         "x64"
       ],
+      "dev": true,
+      "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
@@ -3489,19 +3533,21 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-x64": "1.2.3"
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
       }
     },
     "node_modules/@img/sharp-wasm32": {
-      "version": "0.34.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.4.tgz",
-      "integrity": "sha512-33QL6ZO/qpRyG7woB/HUALz28WnTMI2W1jgX3Nu2bypqLIKx/QKMILLJzJjI+SIbvXdG9fUnmrxR7vbi1sTBeA==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
       "cpu": [
         "wasm32"
       ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/runtime": "^1.5.0"
+        "@emnapi/runtime": "^1.7.0"
       },
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
@@ -3511,12 +3557,14 @@
       }
     },
     "node_modules/@img/sharp-win32-arm64": {
-      "version": "0.34.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.4.tgz",
-      "integrity": "sha512-2Q250do/5WXTwxW3zjsEuMSv5sUU4Tq9VThWKlU2EYLm4MB7ZeMwF+SFJutldYODXF6jzc6YEOC+VfX0SZQPqA==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
       "cpu": [
         "arm64"
       ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
         "win32"
@@ -3529,12 +3577,14 @@
       }
     },
     "node_modules/@img/sharp-win32-ia32": {
-      "version": "0.34.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.4.tgz",
-      "integrity": "sha512-3ZeLue5V82dT92CNL6rsal6I2weKw1cYu+rGKm8fOCCtJTR2gYeUfY3FqUnIJsMUPIH68oS5jmZ0NiJ508YpEw==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
       "cpu": [
         "ia32"
       ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
         "win32"
@@ -3547,12 +3597,14 @@
       }
     },
     "node_modules/@img/sharp-win32-x64": {
-      "version": "0.34.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.4.tgz",
-      "integrity": "sha512-xIyj4wpYs8J18sVN3mSQjwrw7fKUqRw+Z5rnHNCy5fYTxigBz81u5mOMPmFumwjcn8+ld1ppptMBCLic1nz6ig==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
       "cpu": [
         "x64"
       ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
       "optional": true,
       "os": [
         "win32"
@@ -4655,6 +4707,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/@mdx-js/loader/-/loader-3.1.1.tgz",
       "integrity": "sha512-0TTacJyZ9mDmY+VefuthVshaNIyCGZHJG2fMnGaDttCt8HmjUF7SizlHJpaCDoGnN635nK1wpzfpx/Xx5S4WnQ==",
+      "peer": true,
       "dependencies": {
         "@mdx-js/mdx": "^3.0.0",
         "source-map": "^0.7.0"
@@ -4712,6 +4765,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-3.1.1.tgz",
       "integrity": "sha512-f++rKLQgUVYDAtECQ6fn/is15GkEH9+nZPM3MS0RcxVqoTfawHvDlSCH7JbMhAM6uJ32v3eXLvLmLvjGu7PTQw==",
+      "peer": true,
       "dependencies": {
         "@types/mdx": "^2.0.0"
       },
@@ -4832,13 +4886,15 @@
       "version": "15.5.14",
       "resolved": "https://registry.npmjs.org/@next/env/-/env-15.5.14.tgz",
       "integrity": "sha512-aXeirLYuASxEgi4X4WhfXsShCFxWDfNn/8ZeC5YXAS2BB4A8FJi1kwwGL6nvMVboE7fZCzmJPNdMvVHc8JpaiA==",
+      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
-      "version": "15.4.1",
-      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-15.4.1.tgz",
-      "integrity": "sha512-lQnHUxN7mMksK7IxgKDIXNMWFOBmksVrjamMEURXiYfo7zgsc30lnU8u4y/MJktSh+nB80ktTQeQbWdQO6c8Ow==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-16.2.3.tgz",
+      "integrity": "sha512-nE/b9mht28XJxjTwKs/yk7w4XTaU3t40UHVAky6cjiijdP/SEy3hGsnQMPxmXPTpC7W4/97okm6fngKnvCqVaA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "fast-glob": "3.3.1"
       }
@@ -4848,6 +4904,7 @@
       "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz",
       "integrity": "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
@@ -4864,6 +4921,7 @@
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
       "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.1"
       },
@@ -4872,9 +4930,10 @@
       }
     },
     "node_modules/@next/mdx": {
-      "version": "15.5.6",
-      "resolved": "https://registry.npmjs.org/@next/mdx/-/mdx-15.5.6.tgz",
-      "integrity": "sha512-lyzXcnZWPjYxbkz/5tv1bRlCOjKYX1lFg3LIuoIf9ERTOUBDzkCvUnWjtRsmFRxKv1/6uwpLVQvrJDd54gVDBw==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/mdx/-/mdx-16.2.3.tgz",
+      "integrity": "sha512-mm7XNfPagSIcN8jFtozB9toeh5ESES0KCLRoo0gu6xydijvnIrV7dRIK3akNL3Tecc8AHX1FNzYZOZTeFU6RCw==",
+      "license": "MIT",
       "dependencies": {
         "source-map": "^0.7.0"
       },
@@ -4898,6 +4957,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4914,6 +4974,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4930,6 +4991,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4946,6 +5008,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4962,6 +5025,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4978,6 +5042,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4994,6 +5059,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5010,6 +5076,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5092,6 +5159,7 @@
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
       "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "peer": true,
       "engines": {
         "node": ">=8.0.0"
       }
@@ -5111,6 +5179,7 @@
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.6.0.tgz",
       "integrity": "sha512-L8UyDwqpTcbkIK5cgwDRDYDoEhQoj8wp8BwsO19w3LB1Z41yEQm2VJyNfAi9DrLP/YTqXqWpKHyZfR9/tFYo1Q==",
+      "peer": true,
       "engines": {
         "node": "^18.19.0 || >=20.6.0"
       },
@@ -5122,6 +5191,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.2.0.tgz",
       "integrity": "sha512-FuabnnUm8LflnieVxs6eP7Z383hgQU4W1e3KJS6aOG3RxWxcHyBxH8fDMHNgu/gFx/M2jvTOW/4/PHhLz6bjWw==",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/semantic-conventions": "^1.29.0"
       },
@@ -5696,6 +5766,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.2.0.tgz",
       "integrity": "sha512-xWQgL0Bmctsalg6PaXExmzdedSp3gyKV8mQBwK/j9VGdCDu2fmXIb2gAehBKbkXCpJ4HPkgv3QfoJWRT4dHWbw==",
+      "peer": true,
       "dependencies": {
         "@opentelemetry/core": "2.2.0",
         "@opentelemetry/resources": "2.2.0",
@@ -5727,6 +5798,7 @@
       "version": "1.39.0",
       "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.39.0.tgz",
       "integrity": "sha512-R5R9tb2AXs2IRLNKLBJDynhkfmx7mX0vi8NkhZb3gUkPWHn6HXk5J8iQ/dql0U3ApfWym4kXXmBDRGO+oeOfjg==",
+      "peer": true,
       "engines": {
         "node": ">=14"
       }
@@ -5901,6 +5973,7 @@
       "resolved": "https://registry.npmjs.org/@parcel/core/-/core-2.9.3.tgz",
       "integrity": "sha512-4KlM1Zr/jpsqWuMXr2zmGsaOUs1zMMFh9vfCNKRZkptf+uk8I3sugHbNdo+F5B+4e2yMuOEb1zgAmvJLeuH6ww==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@mischnic/json-sourcemap": "^0.1.0",
         "@parcel/cache": "2.9.3",
@@ -7784,7 +7857,7 @@
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/@parcel/watcher/-/watcher-2.5.1.tgz",
       "integrity": "sha512-dfUnCxiN9H4ap84DvD2ubjw+3vUNpstxa0TneY/Paat8a3R4uQZDLSvWjmznAY/DoahqTHl9V46HF/Zs3F29pg==",
-      "devOptional": true,
+      "dev": true,
       "hasInstallScript": true,
       "dependencies": {
         "detect-libc": "^1.0.3",
@@ -7822,6 +7895,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "android"
@@ -7841,6 +7915,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -7860,6 +7935,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "darwin"
@@ -7879,6 +7955,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "freebsd"
@@ -7898,6 +7975,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -7917,6 +7995,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -7936,6 +8015,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -7955,6 +8035,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -7974,6 +8055,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -7993,6 +8075,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -8012,6 +8095,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -8031,6 +8115,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -8050,6 +8135,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "optional": true,
       "os": [
         "win32"
@@ -8066,7 +8152,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
       "integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
-      "devOptional": true,
+      "dev": true,
       "bin": {
         "detect-libc": "bin/detect-libc.js"
       },
@@ -8724,6 +8810,7 @@
       "integrity": "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==",
       "dev": true,
       "hasInstallScript": true,
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -8890,6 +8977,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.2.2.tgz",
       "integrity": "sha512-mI4WrpHsbCIcwT9cF4FZvr80QUeKvsUsUvKDoR+X/7XHQH98xYD8YHZg7ANtz2GtZt/CBq2QJ0thkGJMHfqc1w==",
       "dev": true,
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -10201,12 +10289,6 @@
       "integrity": "sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==",
       "dev": true
     },
-    "node_modules/@rushstack/eslint-patch": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/@rushstack/eslint-patch/-/eslint-patch-1.14.0.tgz",
-      "integrity": "sha512-WJFej426qe4RWOm9MMtP4V3CV4AucXolQty+GRgAWLgQXmpCuwzs7hEpxxhSc/znXUSxum9d/P/32MW0FlAAlA==",
-      "dev": true
-    },
     "node_modules/@sec-ant/readable-stream": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/@sec-ant/readable-stream/-/readable-stream-0.4.1.tgz",
@@ -10555,7 +10637,6 @@
       "integrity": "sha512-dRBP2TnX6fGdS0T2mXBHjkS/3Nlu1ra1huovZVFuM67CYMzrhM/3hX/zru1vWSC5rqY93ZaAhjMciPW4pK5mMQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@storybook/theming": "8.6.18",
         "better-opn": "^3.0.2",
@@ -10588,7 +10669,6 @@
       "integrity": "sha512-n6OEjEtHupa2PdTwWzRepr7cO8NkDd4rgF6BKLitRbujOspLxzMBEqdphs+QLcuiCIgf33SqmEA64QWnbSMhPw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/storybook"
@@ -10924,6 +11004,7 @@
       "resolved": "https://registry.npmjs.org/@svgr/core/-/core-6.5.1.tgz",
       "integrity": "sha512-/xdLSWxK5QkqG524ONSjvg3V/FkNyCv538OIBdQqPNaAta3AsXj/Bd2FbvR87yMbXO2hFSWiAe/Q6IkVPDw+mw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@babel/core": "^7.19.6",
         "@svgr/babel-preset": "^6.5.1",
@@ -11396,7 +11477,6 @@
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -11416,7 +11496,6 @@
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -11426,7 +11505,6 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -11439,7 +11517,6 @@
       "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
       "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "dequal": "^2.0.3"
       }
@@ -11449,7 +11526,6 @@
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -11463,8 +11539,7 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/@testing-library/jest-dom": {
       "version": "6.9.1",
@@ -11534,8 +11609,7 @@
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -11699,6 +11773,7 @@
       "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.3.tgz",
       "integrity": "sha512-wGA0NX93b19/dZC1J18tKWVIYWyyF2ZjT9vin/NRu0qzzvfVzWjs04iq2rQ3H65vCTQYlRqs3YHfY7zjdV+9Kw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@types/body-parser": "*",
         "@types/express-serve-static-core": "^5.0.0",
@@ -11826,7 +11901,8 @@
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
-      "dev": true
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/json5": {
       "version": "0.0.29",
@@ -11886,6 +11962,7 @@
       "version": "20.19.23",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.23.tgz",
       "integrity": "sha512-yIdlVVVHXpmqRhtyovZAcSy0MiPcYWGkoO4CGe/+jpP0hmNuihm4XhHbADpK++MsiLHP5MVlv+bcgdF99kSiFQ==",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -11927,20 +12004,23 @@
       "dev": true
     },
     "node_modules/@types/react": {
-      "version": "19.1.8",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.8.tgz",
-      "integrity": "sha512-AwAfQ2Wa5bCx9WP8nZL2uMZWod7J7/JSplxbTmBQ5ms6QpqNYm672H0Vu9ZVKVngQ+ii4R/byguVEUZQyeg44g==",
+      "version": "19.2.14",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
+      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "csstype": "^3.0.2"
+        "csstype": "^3.2.2"
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "19.1.6",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.6.tgz",
-      "integrity": "sha512-4hOiT/dwO8Ko0gV1m/TJZYk3y0KBnY9vzDh7W+DH17b2HFSOGgdj33dhihPeuy3l0q23+4e+hoXHV6hCC4dCXw==",
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
+      "license": "MIT",
       "peerDependencies": {
-        "@types/react": "^19.0.0"
+        "@types/react": "^19.2.0"
       }
     },
     "node_modules/@types/relateurl": {
@@ -12096,20 +12176,20 @@
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.46.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.46.2.tgz",
-      "integrity": "sha512-ZGBMToy857/NIPaaCucIUQgqueOiq7HeAKkhlvqVV4lm089zUFW6ikRySx2v+cAhKeUCPuWVHeimyk6Dw1iY3w==",
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.58.1.tgz",
+      "integrity": "sha512-eSkwoemjo76bdXl2MYqtxg51HNwUSkWfODUOQ3PaTLZGh9uIWWFZIjyjaJnex7wXDu+TRx+ATsnSxdN9YWfRTQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.46.2",
-        "@typescript-eslint/type-utils": "8.46.2",
-        "@typescript-eslint/utils": "8.46.2",
-        "@typescript-eslint/visitor-keys": "8.46.2",
-        "graphemer": "^1.4.0",
-        "ignore": "^7.0.0",
+        "@eslint-community/regexpp": "^4.12.2",
+        "@typescript-eslint/scope-manager": "8.58.1",
+        "@typescript-eslint/type-utils": "8.58.1",
+        "@typescript-eslint/utils": "8.58.1",
+        "@typescript-eslint/visitor-keys": "8.58.1",
+        "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
-        "ts-api-utils": "^2.1.0"
+        "ts-api-utils": "^2.5.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -12119,22 +12199,24 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.46.2",
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "@typescript-eslint/parser": "^8.58.1",
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.46.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.46.2.tgz",
-      "integrity": "sha512-BnOroVl1SgrPLywqxyqdJ4l3S2MsKVLDVxZvjI1Eoe8ev2r3kGDo+PcMihNmDE+6/KjkTubSJnmqGZZjQSBq/g==",
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.58.1.tgz",
+      "integrity": "sha512-gGkiNMPqerb2cJSVcruigx9eHBlLG14fSdPdqMoOcBfh+vvn4iCq2C8MzUB89PrxOXk0y3GZ1yIWb9aOzL93bw==",
       "dev": true,
+      "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.46.2",
-        "@typescript-eslint/types": "8.46.2",
-        "@typescript-eslint/typescript-estree": "8.46.2",
-        "@typescript-eslint/visitor-keys": "8.46.2",
-        "debug": "^4.3.4"
+        "@typescript-eslint/scope-manager": "8.58.1",
+        "@typescript-eslint/types": "8.58.1",
+        "@typescript-eslint/typescript-estree": "8.58.1",
+        "@typescript-eslint/visitor-keys": "8.58.1",
+        "debug": "^4.4.3"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -12144,19 +12226,20 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.46.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.46.2.tgz",
-      "integrity": "sha512-PULOLZ9iqwI7hXcmL4fVfIsBi6AN9YxRc0frbvmg8f+4hQAjQ5GYNKK0DIArNo+rOKmR/iBYwkpBmnIwin4wBg==",
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.58.1.tgz",
+      "integrity": "sha512-gfQ8fk6cxhtptek+/8ZIqw8YrRW5048Gug8Ts5IYcMLCw18iUgrZAEY/D7s4hkI0FxEfGakKuPK/XUMPzPxi5g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.46.2",
-        "@typescript-eslint/types": "^8.46.2",
-        "debug": "^4.3.4"
+        "@typescript-eslint/tsconfig-utils": "^8.58.1",
+        "@typescript-eslint/types": "^8.58.1",
+        "debug": "^4.4.3"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -12166,17 +12249,18 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.46.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.46.2.tgz",
-      "integrity": "sha512-LF4b/NmGvdWEHD2H4MsHD8ny6JpiVNDzrSZr3CsckEgCbAGZbYM4Cqxvi9L+WqDMT+51Ozy7lt2M+d0JLEuBqA==",
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.58.1.tgz",
+      "integrity": "sha512-TPYUEqJK6avLcEjumWsIuTpuYODTTDAtoMdt8ZZa93uWMTX13Nb8L5leSje1NluammvU+oI3QRr5lLXPgihX3w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.46.2",
-        "@typescript-eslint/visitor-keys": "8.46.2"
+        "@typescript-eslint/types": "8.58.1",
+        "@typescript-eslint/visitor-keys": "8.58.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -12187,10 +12271,11 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.46.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.46.2.tgz",
-      "integrity": "sha512-a7QH6fw4S57+F5y2FIxxSDyi5M4UfGF+Jl1bCGd7+L4KsaUY80GsiF/t0UoRFDHAguKlBaACWJRmdrc6Xfkkag==",
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.58.1.tgz",
+      "integrity": "sha512-JAr2hOIct2Q+qk3G+8YFfqkqi7sC86uNryT+2i5HzMa2MPjw4qNFvtjnw1IiA1rP7QhNKVe21mSSLaSjwA1Olw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -12199,20 +12284,21 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.46.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.46.2.tgz",
-      "integrity": "sha512-HbPM4LbaAAt/DjxXaG9yiS9brOOz6fabal4uvUmaUYe6l3K1phQDMQKBRUrr06BQkxkvIZVVHttqiybM9nJsLA==",
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.58.1.tgz",
+      "integrity": "sha512-HUFxvTJVroT+0rXVJC7eD5zol6ID+Sn5npVPWoFuHGg9Ncq5Q4EYstqR+UOqaNRFXi5TYkpXXkLhoCHe3G0+7w==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.46.2",
-        "@typescript-eslint/typescript-estree": "8.46.2",
-        "@typescript-eslint/utils": "8.46.2",
-        "debug": "^4.3.4",
-        "ts-api-utils": "^2.1.0"
+        "@typescript-eslint/types": "8.58.1",
+        "@typescript-eslint/typescript-estree": "8.58.1",
+        "@typescript-eslint/utils": "8.58.1",
+        "debug": "^4.4.3",
+        "ts-api-utils": "^2.5.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -12222,15 +12308,16 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.46.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.46.2.tgz",
-      "integrity": "sha512-lNCWCbq7rpg7qDsQrd3D6NyWYu+gkTENkG5IKYhUIcxSb59SQC/hEQ+MrG4sTgBVghTonNWq42bA/d4yYumldQ==",
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.58.1.tgz",
+      "integrity": "sha512-io/dV5Aw5ezwzfPBBWLoT+5QfVtP8O7q4Kftjn5azJ88bYyp/ZMCsyW1lpKK46EXJcaYMZ1JtYj+s/7TdzmQMw==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -12240,21 +12327,21 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.46.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.46.2.tgz",
-      "integrity": "sha512-f7rW7LJ2b7Uh2EiQ+7sza6RDZnajbNbemn54Ob6fRwQbgcIn+GWfyuHDHRYgRoZu1P4AayVScrRW+YfbTvPQoQ==",
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.58.1.tgz",
+      "integrity": "sha512-w4w7WR7GHOjqqPnvAYbazq+Y5oS68b9CzasGtnd6jIeOIeKUzYzupGTB2T4LTPSv4d+WPeccbxuneTFHYgAAWg==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.46.2",
-        "@typescript-eslint/tsconfig-utils": "8.46.2",
-        "@typescript-eslint/types": "8.46.2",
-        "@typescript-eslint/visitor-keys": "8.46.2",
-        "debug": "^4.3.4",
-        "fast-glob": "^3.3.2",
-        "is-glob": "^4.0.3",
-        "minimatch": "^9.0.4",
-        "semver": "^7.6.0",
-        "ts-api-utils": "^2.1.0"
+        "@typescript-eslint/project-service": "8.58.1",
+        "@typescript-eslint/tsconfig-utils": "8.58.1",
+        "@typescript-eslint/types": "8.58.1",
+        "@typescript-eslint/visitor-keys": "8.58.1",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -12264,19 +12351,59 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "typescript": ">=4.8.4 <6.0.0"
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.46.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.46.2.tgz",
-      "integrity": "sha512-sExxzucx0Tud5tE0XqR0lT0psBQvEpnpiul9XbGUB1QwpWJJAps1O/Z7hJxLGiZLBKMCutjTzDgmd1muEhBnVg==",
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.58.1.tgz",
+      "integrity": "sha512-Ln8R0tmWC7pTtLOzgJzYTXSCjJ9rDNHAqTaVONF4FEi2qwce8mD9iSOxOpLFFvWp/wBFlew0mjM1L1ihYWfBdQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@eslint-community/eslint-utils": "^4.7.0",
-        "@typescript-eslint/scope-manager": "8.46.2",
-        "@typescript-eslint/types": "8.46.2",
-        "@typescript-eslint/typescript-estree": "8.46.2"
+        "@eslint-community/eslint-utils": "^4.9.1",
+        "@typescript-eslint/scope-manager": "8.58.1",
+        "@typescript-eslint/types": "8.58.1",
+        "@typescript-eslint/typescript-estree": "8.58.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -12286,18 +12413,19 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0",
-        "typescript": ">=4.8.4 <6.0.0"
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.46.2",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.46.2.tgz",
-      "integrity": "sha512-tUFMXI4gxzzMXt4xpGJEsBsTox0XbNQ1y94EwlD/CuZwFcQP79xfQqMhau9HsRc/J0cAPA/HZt1dZPtGn9V/7w==",
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.58.1.tgz",
+      "integrity": "sha512-y+vH7QE8ycjoa0bWciFg7OpFcipUuem1ujhrdLtq1gByKwfbC7bPeKsiny9e0urg93DqwGcHey+bGRKCnF1nZQ==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.46.2",
-        "eslint-visitor-keys": "^4.2.1"
+        "@typescript-eslint/types": "8.58.1",
+        "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -12308,12 +12436,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
-      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
       "dev": true,
+      "license": "Apache-2.0",
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
@@ -12708,6 +12837,7 @@
       "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
       "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@vitest/utils": "3.2.4",
         "pathe": "^2.0.3",
@@ -12992,6 +13122,7 @@
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -13019,7 +13150,6 @@
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/aframe/-/aframe-1.7.1.tgz",
       "integrity": "sha512-dcc7PWI5z8pyJ0s2W0mUd8d83339frgMXhUvWr1yxkdgg6zSExkuQwsSJjiNn7XWKMUUqKYDvV/WzQQRA+OBXA==",
-      "peer": true,
       "dependencies": {
         "buffer": "^6.0.3",
         "debug": "^4.3.4",
@@ -13067,8 +13197,7 @@
       "name": "super-three",
       "version": "0.173.5",
       "resolved": "https://registry.npmjs.org/super-three/-/super-three-0.173.5.tgz",
-      "integrity": "sha512-ecjojbhUg/5QrixwqF4s6gvtJap9XQz7TcnFUX/J8Yosgb2eE2ZUqsyqr/JczFG//6hwIaZPeAa9M5DNaM1dmQ==",
-      "peer": true
+      "integrity": "sha512-ecjojbhUg/5QrixwqF4s6gvtJap9XQz7TcnFUX/J8Yosgb2eE2ZUqsyqr/JczFG//6hwIaZPeAa9M5DNaM1dmQ=="
     },
     "node_modules/agent-base": {
       "version": "7.1.4",
@@ -13099,8 +13228,7 @@
     "node_modules/an-array": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/an-array/-/an-array-1.0.0.tgz",
-      "integrity": "sha512-M175GYI7RmsYu24Ok383yZQa3eveDfNnmhTe3OQ3bm70bEovz2gWenH+ST/n32M8lrwLWk74hcPds5CDRPe2wg==",
-      "peer": true
+      "integrity": "sha512-M175GYI7RmsYu24Ok383yZQa3eveDfNnmhTe3OQ3bm70bEovz2gWenH+ST/n32M8lrwLWk74hcPds5CDRPe2wg=="
     },
     "node_modules/ansi-escapes": {
       "version": "4.3.2",
@@ -13286,7 +13414,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/array-shuffle/-/array-shuffle-1.0.1.tgz",
       "integrity": "sha512-PBqgo1Y2XWSksBzq3GFPEb798ZrW2snAcmr4drbVeF/6MT/5aBlkGJEvu5A/CzXHf4EjbHOj/ZowatjlIiVidA==",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -13417,8 +13544,7 @@
     "node_modules/as-number": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/as-number/-/as-number-1.0.0.tgz",
-      "integrity": "sha512-HkI/zLo2AbSRO4fqVkmyf3hms0bJDs3iboHqTrNuwTiCRvdYXM7HFhfhB6Dk51anV2LM/IMB83mtK9mHw4FlAg==",
-      "peer": true
+      "integrity": "sha512-HkI/zLo2AbSRO4fqVkmyf3hms0bJDs3iboHqTrNuwTiCRvdYXM7HFhfhB6Dk51anV2LM/IMB83mtK9mHw4FlAg=="
     },
     "node_modules/asap": {
       "version": "2.0.6",
@@ -13920,12 +14046,15 @@
       ]
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.8.19",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.19.tgz",
-      "integrity": "sha512-zoKGUdu6vb2jd3YOq0nnhEDQVbPcHhco3UImJrv5dSkvxTc2pl2WjOPsjZXDwPDSl5eghIMuY3R6J9NDKF3KcQ==",
-      "dev": true,
+      "version": "2.10.17",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.17.tgz",
+      "integrity": "sha512-HdrkN8eVG2CXxeifv/VdJ4A4RSra1DTW8dc/hdxzhGHN8QePs6gKaWM9pHPcpCoxYZJuOZ8drHmbdpLHjCYjLA==",
+      "license": "Apache-2.0",
       "bin": {
-        "baseline-browser-mapping": "dist/cli.js"
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/bcrypt-pbkdf": {
@@ -14063,7 +14192,7 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
       "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "fill-range": "^7.1.1"
       },
@@ -14075,8 +14204,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/browser-assert/-/browser-assert-1.2.1.tgz",
       "integrity": "sha512-nfulgvOR6S4gt9UKCeGJOuSGBPGiFT6oQ/2UBnvTY/5aQ1PnksW72fhZkM30DzoRRv2WpwZf1vHHEr3mtuXIWQ==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/browserslist": {
       "version": "4.27.0",
@@ -14097,6 +14225,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.19",
         "caniuse-lite": "^1.0.30001751",
@@ -14168,7 +14297,6 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-0.0.1.tgz",
       "integrity": "sha512-RgSV6InVQ9ODPdLWJ5UAqBqJBOg370Nz6ZQtRzpt6nUjc8v0St97uJ4PYC6NztqIScrAXafKM3mZPMygSe1ggA==",
-      "peer": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -14462,7 +14590,6 @@
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/centra/-/centra-2.7.0.tgz",
       "integrity": "sha512-PbFMgMSrmgx6uxCdm57RUos9Tc3fclMvhLSATYN39XsDV29B89zZ3KA89jmY0vwSGazyU+uerqwa6t+KaodPcg==",
-      "peer": true,
       "dependencies": {
         "follow-redirects": "^1.15.6"
       }
@@ -14906,7 +15033,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/clone-response/-/clone-response-1.0.3.tgz",
       "integrity": "sha512-ROoL94jJH2dUVML2Y/5PEDNaSHgeOdSDicUyS7izcF63G6sTc/FTjLub4b8Il9S8S0beOfYt0TaA5qvFK+w0wA==",
-      "peer": true,
       "dependencies": {
         "mimic-response": "^1.0.0"
       },
@@ -14918,7 +15044,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
       "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
-      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -15516,9 +15641,10 @@
       }
     },
     "node_modules/csstype": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "license": "MIT"
     },
     "node_modules/d3-array": {
       "version": "3.2.4",
@@ -15650,6 +15776,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -15810,7 +15937,8 @@
     "node_modules/dayjs": {
       "version": "1.11.18",
       "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.18.tgz",
-      "integrity": "sha512-zFBQ7WFRvVRhKcWoUh+ZA1g2HVgUbsZm9sbddh8EC5iv93sui8DVVz1Npvz+r6meo9VKfa8NyLWBsQK1VvIKPA=="
+      "integrity": "sha512-zFBQ7WFRvVRhKcWoUh+ZA1g2HVgUbsZm9sbddh8EC5iv93sui8DVVz1Npvz+r6meo9VKfa8NyLWBsQK1VvIKPA==",
+      "peer": true
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -15891,7 +16019,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/deep-assign/-/deep-assign-2.0.0.tgz",
       "integrity": "sha512-2QhG3Kxulu4XIF3WL5C5x0sc/S17JLgm1SfvDfIRsR/5m7ZGmcejII7fZ2RyWhN0UWIJm0TNM/eKow6LAn3evQ==",
-      "peer": true,
       "dependencies": {
         "is-obj": "^1.0.0"
       },
@@ -16231,8 +16358,7 @@
       "version": "0.5.16",
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
-      "dev": true,
-      "peer": true
+      "dev": true
     },
     "node_modules/dom-helpers": {
       "version": "5.2.1",
@@ -16269,8 +16395,7 @@
     "node_modules/dom-walk": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.2.tgz",
-      "integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w==",
-      "peer": true
+      "integrity": "sha512-6QvTW9mrGeIegrFXdtQi9pk7O/nSK6lSdXW2eqUspN5LWD7UTji2Fqw5V2YLjBpHEoU9Xl/eUWNpDeZvoyOv2w=="
     },
     "node_modules/domelementtype": {
       "version": "2.3.0",
@@ -16496,7 +16621,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/dtype/-/dtype-2.0.0.tgz",
       "integrity": "sha512-s2YVcLKdFGS0hpFqJaTwscsyt0E8nNFdmo73Ocd81xNPj4URI4rj6D60A+vFMIw7BXWlb4yRkEwfBqcZzPGiZg==",
-      "peer": true,
       "engines": {
         "node": ">= 0.8.0"
       }
@@ -16517,8 +16641,7 @@
     "node_modules/duplexer3": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.5.tgz",
-      "integrity": "sha512-1A8za6ws41LQgv9HrE/66jyC5yuSjQ3L/KOpFtoBilsAK2iA2wuS5rTt1OCzIvtS2V7nVmedsUU+DGRcjBmOYA==",
-      "peer": true
+      "integrity": "sha512-1A8za6ws41LQgv9HrE/66jyC5yuSjQ3L/KOpFtoBilsAK2iA2wuS5rTt1OCzIvtS2V7nVmedsUU+DGRcjBmOYA=="
     },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
@@ -16544,6 +16667,7 @@
       "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.10.tgz",
       "integrity": "sha512-UeJmFfOrAQS8OJWPZ4qtgHyWExa088/MtK5UEyoJGFH67cDEXkZSviOiKRCZ4Xij0zxI3JECgYs3oKx+AizQBA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "jake": "^10.8.5"
       },
@@ -16856,6 +16980,7 @@
       "integrity": "sha512-KohQwyzrKTQmhXDW1PjCv3Tyspn9n5GcY2RTDqeORIdIJY8yKIF7sTSopFmn/wpMPW4rdPXI0UE5LJLuq3bx0Q==",
       "dev": true,
       "hasInstallScript": true,
+      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -16930,24 +17055,26 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.38.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.38.0.tgz",
-      "integrity": "sha512-t5aPOpmtJcZcz5UJyY2GbvpDlsK5E8JqRqoKtfiKE3cNh437KIqfJr3A3AKf5k64NPx6d0G3dno6XDY05PqPtw==",
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
+      "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
+      "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
-        "@eslint/config-array": "^0.21.1",
-        "@eslint/config-helpers": "^0.4.1",
-        "@eslint/core": "^0.16.0",
-        "@eslint/eslintrc": "^3.3.1",
-        "@eslint/js": "9.38.0",
-        "@eslint/plugin-kit": "^0.4.0",
+        "@eslint/config-array": "^0.21.2",
+        "@eslint/config-helpers": "^0.4.2",
+        "@eslint/core": "^0.17.0",
+        "@eslint/eslintrc": "^3.3.5",
+        "@eslint/js": "9.39.4",
+        "@eslint/plugin-kit": "^0.4.1",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",
         "@types/estree": "^1.0.6",
-        "ajv": "^6.12.4",
+        "ajv": "^6.14.0",
         "chalk": "^4.0.0",
         "cross-spawn": "^7.0.6",
         "debug": "^4.3.2",
@@ -16966,7 +17093,7 @@
         "is-glob": "^4.0.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
         "lodash.merge": "^4.6.2",
-        "minimatch": "^3.1.2",
+        "minimatch": "^3.1.5",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.3"
       },
@@ -16989,24 +17116,24 @@
       }
     },
     "node_modules/eslint-config-next": {
-      "version": "15.4.1",
-      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-15.4.1.tgz",
-      "integrity": "sha512-XIIN+lq8XuSwXUrcv+0uHMDFGJFPxLAw04/a4muFZYygSvStvVa15nY7kh4Il6yOVJyxdMUyVdQ9ApGedaeupw==",
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-16.2.3.tgz",
+      "integrity": "sha512-Dnkrylzjof/Az7iNoIQJqD18zTxQZcngir19KJaiRsMnnjpQSVoa6aEg/1Q4hQC+cW90uTlgQYadwL1CYNwFWA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "@next/eslint-plugin-next": "15.4.1",
-        "@rushstack/eslint-patch": "^1.10.3",
-        "@typescript-eslint/eslint-plugin": "^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0",
-        "@typescript-eslint/parser": "^5.4.2 || ^6.0.0 || ^7.0.0 || ^8.0.0",
+        "@next/eslint-plugin-next": "16.2.3",
         "eslint-import-resolver-node": "^0.3.6",
         "eslint-import-resolver-typescript": "^3.5.2",
-        "eslint-plugin-import": "^2.31.0",
+        "eslint-plugin-import": "^2.32.0",
         "eslint-plugin-jsx-a11y": "^6.10.0",
         "eslint-plugin-react": "^7.37.0",
-        "eslint-plugin-react-hooks": "^5.0.0"
+        "eslint-plugin-react-hooks": "^7.0.0",
+        "globals": "16.4.0",
+        "typescript-eslint": "^8.46.0"
       },
       "peerDependencies": {
-        "eslint": "^7.23.0 || ^8.0.0 || ^9.0.0",
+        "eslint": ">=9.0.0",
         "typescript": ">=3.3.1"
       },
       "peerDependenciesMeta": {
@@ -17015,11 +17142,25 @@
         }
       }
     },
+    "node_modules/eslint-config-next/node_modules/globals": {
+      "version": "16.4.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-16.4.0.tgz",
+      "integrity": "sha512-ob/2LcVVaVGCYN+r14cnwnoDPUufjiYgSqRhiFD0Q1iI4Odora5RE8Iv1D24hAz5oMophRGkGz+yuvQmmUMnMw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/eslint-config-prettier": {
       "version": "10.1.8",
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -17334,12 +17475,20 @@
       }
     },
     "node_modules/eslint-plugin-react-hooks": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-5.2.0.tgz",
-      "integrity": "sha512-+f15FfK64YQwZdJNELETdn5ibXEUQmW1DZL6KXhNnc2heoy/sg9VJJeT7n8TlMWouzWqSWavFkIhHyIbIAEapg==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.0.1.tgz",
+      "integrity": "sha512-O0d0m04evaNzEPoSW+59Mezf8Qt0InfgGIBJnpC0h3NH/WjUAR7BIKUfysC6todmtiZ/A0oUVS8Gce0WhBrHsA==",
       "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.24.4",
+        "@babel/parser": "^7.24.4",
+        "hermes-parser": "^0.25.1",
+        "zod": "^3.25.0 || ^4.0.0",
+        "zod-validation-error": "^3.5.0 || ^4.0.0"
+      },
       "engines": {
-        "node": ">=10"
+        "node": ">=18"
       },
       "peerDependencies": {
         "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0"
@@ -17544,6 +17693,7 @@
       "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
       "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
       "dev": true,
+      "license": "BSD-2-Clause",
       "dependencies": {
         "acorn": "^8.15.0",
         "acorn-jsx": "^5.3.2",
@@ -17561,6 +17711,7 @@
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
       "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
       "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -18051,7 +18202,7 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
       "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "to-regex-range": "^5.0.1"
       },
@@ -18146,7 +18297,6 @@
           "url": "https://github.com/sponsors/RubenVerborgh"
         }
       ],
-      "peer": true,
       "engines": {
         "node": ">=4.0"
       },
@@ -18535,7 +18685,6 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/global/-/global-4.4.0.tgz",
       "integrity": "sha512-wv/LAoHdRE3BeTGz53FAamhGlPLhlssK45usmGFThIi4XqnBmjKQ16u+RNbP7WvigRZDxUsM0J3gcQ5yicaL0w==",
-      "peer": true,
       "dependencies": {
         "min-document": "^2.19.0",
         "process": "^0.11.10"
@@ -18546,6 +18695,7 @@
       "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
       "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=18"
       },
@@ -18675,6 +18825,7 @@
       "integrity": "sha512-4E71E0rpOaQuJR2A3xDZ+GM1HyWYv1clR58tC8emQNeQe3RH7MAzSbat+V0wG78LQBo6m6bzSG/L4pBuCsgnUQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "minimist": "^1.2.5",
         "neo-async": "^2.6.2",
@@ -18870,6 +19021,23 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hermes-estree": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.1.tgz",
+      "integrity": "sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/hermes-parser": {
+      "version": "0.25.1",
+      "resolved": "https://registry.npmjs.org/hermes-parser/-/hermes-parser-0.25.1.tgz",
+      "integrity": "sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hermes-estree": "0.25.1"
       }
     },
     "node_modules/html-encoding-sniffer": {
@@ -19355,7 +19523,6 @@
       "integrity": "sha512-7bVbi0huj/wrIAOzb8U1aszg9kdi3KN/CyU19CTI7tAoZYEZoL9yCDXpbXN+uPsuWnP02cyug1gleqq+TU+YCA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "call-bound": "^1.0.2",
         "has-tostringtag": "^1.0.2"
@@ -19455,8 +19622,7 @@
     "node_modules/is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-      "peer": true
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
     },
     "node_modules/is-bun-module": {
       "version": "2.0.0",
@@ -19555,7 +19721,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
-      "devOptional": true,
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -19587,8 +19753,7 @@
     "node_modules/is-function": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-function/-/is-function-1.0.2.tgz",
-      "integrity": "sha512-lw7DUp0aWXYg+CBCN+JKkcE0Q2RayZnSvnZBlwgxHBQhqt5pZNVy4Ri7H9GmmXkdu7LUthszM+Tor1u/2iBcpQ==",
-      "peer": true
+      "integrity": "sha512-lw7DUp0aWXYg+CBCN+JKkcE0Q2RayZnSvnZBlwgxHBQhqt5pZNVy4Ri7H9GmmXkdu7LUthszM+Tor1u/2iBcpQ=="
     },
     "node_modules/is-generator-fn": {
       "version": "2.1.0",
@@ -19622,7 +19787,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
       "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "is-extglob": "^2.1.1"
       },
@@ -19673,7 +19838,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-      "devOptional": true,
+      "dev": true,
       "engines": {
         "node": ">=0.12.0"
       }
@@ -19698,7 +19863,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
       "integrity": "sha512-l4RyHgRqGN4Y3+9JHVrNqO+tN0rV5My76uW5/nuO4K1b6vw5G8d/cmFjP9tRfEsdhZNt0IFdZuK/c2Vr4Nb+Qg==",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -20070,6 +20234,7 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -20779,7 +20944,6 @@
       "integrity": "sha512-iZ8Bdb84lWRuGHamRXFyML07r21pcwBrLkHEuHgEY5UbCouBwv7ECknDRKzsQIXMiqpPymqtIf8TC/shYKB5rw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12.0.0"
       }
@@ -20789,6 +20953,7 @@
       "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-26.1.0.tgz",
       "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
@@ -21022,7 +21187,6 @@
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/layout-bmfont-text/-/layout-bmfont-text-1.3.4.tgz",
       "integrity": "sha512-mceomHZ8W7pSKQhTdLvOe1Im4n37u8xa5Gr0J3KPCHRMO/9o7+goWIOzZcUUd+Xgzy3+22bvoIQ0OaN3LRtgaw==",
-      "peer": true,
       "dependencies": {
         "as-number": "^1.0.0",
         "word-wrapper": "^1.0.7",
@@ -21494,7 +21658,6 @@
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/load-bmfont/-/load-bmfont-1.4.2.tgz",
       "integrity": "sha512-qElWkmjW9Oq1F9EI5Gt7aD9zcdHb9spJCW1L/dmPf7KzCCEJxq8nhHz5eCgI9aMf7vrG/wyaCqdsI+Iy9ZTlog==",
-      "peer": true,
       "dependencies": {
         "buffer-equal": "0.0.1",
         "mime": "^1.3.4",
@@ -21510,7 +21673,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
       "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
-      "peer": true,
       "bin": {
         "mime": "cli.js"
       },
@@ -21553,7 +21715,8 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
       "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lodash-es": {
       "version": "4.17.23",
@@ -21696,7 +21859,6 @@
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
-      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -21755,7 +21917,6 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/map-limit/-/map-limit-0.0.1.tgz",
       "integrity": "sha512-pJpcfLPnIF/Sk3taPW21G/RQsEEirGaFpCW3oXRwH9dnFHPHNGjNyvh++rdmC2fNqEaTw2MhYJraoJWAHx8kEg==",
-      "peer": true,
       "dependencies": {
         "once": "~1.3.0"
       }
@@ -21764,7 +21925,6 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
       "integrity": "sha512-6vaNInhu+CHxtONf3zw3vq4SP2DOQhjBvIa3rNcG0+P7eKWlYH6Peu7rHizSloRU2EwMz6GraLieis9Ac9+p1w==",
-      "peer": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -22585,7 +22745,7 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
       "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "braces": "^3.0.3",
         "picomatch": "^2.3.1"
@@ -22598,7 +22758,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
       "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -22663,7 +22823,6 @@
       "version": "2.19.2",
       "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.2.tgz",
       "integrity": "sha512-8S5I8db/uZN8r9HSLFVWPdJCvYOejMcEC82VIzNUc6Zkklf/d1gg2psfE79/vyhWOj4+J8MtwmoOz3TmvaGu5A==",
-      "peer": true,
       "dependencies": {
         "dom-walk": "^0.1.0"
       }
@@ -22909,14 +23068,15 @@
     "node_modules/new-array": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/new-array/-/new-array-1.0.0.tgz",
-      "integrity": "sha512-K5AyFYbuHZ4e/ti52y7k18q8UHsS78FlRd85w2Fmsd6AkuLipDihPflKC0p3PN5i8II7+uHxo+CtkLiJDfmS5A==",
-      "peer": true
+      "integrity": "sha512-K5AyFYbuHZ4e/ti52y7k18q8UHsS78FlRd85w2Fmsd6AkuLipDihPflKC0p3PN5i8II7+uHxo+CtkLiJDfmS5A=="
     },
     "node_modules/next": {
       "version": "15.5.14",
       "resolved": "https://registry.npmjs.org/next/-/next-15.5.14.tgz",
       "integrity": "sha512-M6S+4JyRjmKic2Ssm7jHUPkE6YUJ6lv4507jprsSZLulubz0ihO2E+S4zmQK3JZ2ov81JrugukKU4Tz0ivgqqQ==",
+      "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@next/env": "15.5.14",
         "@swc/helpers": "0.5.15",
@@ -22968,6 +23128,7 @@
       "version": "8.4.31",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
       "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "devOptional": true,
       "funding": [
         {
           "type": "opencollective",
@@ -23028,7 +23189,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/nice-color-palettes/-/nice-color-palettes-3.0.0.tgz",
       "integrity": "sha512-lL4AjabAAFi313tjrtmgm/bxCRzp4l3vCshojfV/ij3IPdtnRqv6Chcw+SqJUhbe7g3o3BecaqCJYUNLswGBhQ==",
-      "peer": true,
       "dependencies": {
         "got": "^9.2.2",
         "map-limit": "0.0.1",
@@ -23043,7 +23203,6 @@
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
       "integrity": "sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -23052,7 +23211,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-1.1.2.tgz",
       "integrity": "sha512-XIB2XbzHTN6ieIjfIMV9hlVcfPU26s2vafYWQcZHWXHOxiaRZYEDKEwdl129Zyg50+foYV2jCgtrqSA6qNuNSA==",
-      "peer": true,
       "dependencies": {
         "defer-to-connect": "^1.0.1"
       },
@@ -23064,7 +23222,6 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-6.1.0.tgz",
       "integrity": "sha512-Oj3cAGPCqOZX7Rz64Uny2GYAZNliQSqfbePrgAQ1wKAihYmCUnraBtJtKcGR4xz7wF+LoJC+ssFZvv5BgF9Igg==",
-      "peer": true,
       "dependencies": {
         "clone-response": "^1.0.2",
         "get-stream": "^5.1.0",
@@ -23082,7 +23239,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
       "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-      "peer": true,
       "dependencies": {
         "pump": "^3.0.0"
       },
@@ -23097,7 +23253,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
       "integrity": "sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -23106,7 +23261,6 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
       "integrity": "sha512-BzRPQuY1ip+qDonAOz42gRm/pg9F768C+npV/4JOsxRC2sq+Rlk+Q4ZCAsOhnIaMrgarILY+RMUIvMmmX1qAEA==",
-      "peer": true,
       "dependencies": {
         "mimic-response": "^1.0.0"
       },
@@ -23117,14 +23271,12 @@
     "node_modules/nice-color-palettes/node_modules/defer-to-connect": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-1.1.3.tgz",
-      "integrity": "sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ==",
-      "peer": true
+      "integrity": "sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ=="
     },
     "node_modules/nice-color-palettes/node_modules/get-stream": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
       "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
-      "peer": true,
       "dependencies": {
         "pump": "^3.0.0"
       },
@@ -23136,7 +23288,6 @@
       "version": "9.6.0",
       "resolved": "https://registry.npmjs.org/got/-/got-9.6.0.tgz",
       "integrity": "sha512-R7eWptXuGYxwijs0eV+v3o6+XH1IqVK8dJOEecQfTmkncw9AV4dcw/Dhxi8MdlqPthxxpZyizMzyg8RTmEsG+Q==",
-      "peer": true,
       "dependencies": {
         "@sindresorhus/is": "^0.14.0",
         "@szmarczak/http-timer": "^1.1.2",
@@ -23157,14 +23308,12 @@
     "node_modules/nice-color-palettes/node_modules/json-buffer": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",
-      "integrity": "sha512-CuUqjv0FUZIdXkHPI8MezCnFCdaTAacej1TZYulLoAg1h/PhwkdXFN4V/gzY4g+fMBCOV2xF+rp7t2XD2ns/NQ==",
-      "peer": true
+      "integrity": "sha512-CuUqjv0FUZIdXkHPI8MezCnFCdaTAacej1TZYulLoAg1h/PhwkdXFN4V/gzY4g+fMBCOV2xF+rp7t2XD2ns/NQ=="
     },
     "node_modules/nice-color-palettes/node_modules/keyv": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-3.1.0.tgz",
       "integrity": "sha512-9ykJ/46SN/9KPM/sichzQ7OvXyGDYKGTaDlKMGCAlg2UK8KRy4jb0d8sFc+0Tt0YYnThq8X2RZgCg74RPxgcVA==",
-      "peer": true,
       "dependencies": {
         "json-buffer": "3.0.0"
       }
@@ -23173,7 +23322,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
       "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -23182,7 +23330,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
       "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
-      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -23191,7 +23338,6 @@
       "version": "4.5.1",
       "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.5.1.tgz",
       "integrity": "sha512-9UZCFRHQdNrfTpGg8+1INIg93B6zE0aXMVFkw1WFwvO4SlZywU6aLg5Of0Ap/PgcbSw4LNxvMWXMeugwMCX0AA==",
-      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -23200,7 +23346,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-1.1.0.tgz",
       "integrity": "sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw==",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -23209,7 +23354,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/responselike/-/responselike-1.0.2.tgz",
       "integrity": "sha512-/Fpe5guzJk1gPqdJLJR5u7eG/gNY4nImjbRDaVWVMRhne55TCmj2i9Q+54PBRfatRC8v/rIiv9BN0pMd9OV5EQ==",
-      "peer": true,
       "dependencies": {
         "lowercase-keys": "^1.0.0"
       }
@@ -23228,7 +23372,7 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
       "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/node-fetch": {
       "version": "2.7.0",
@@ -23875,20 +24019,17 @@
     "node_modules/parse-bmfont-ascii": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/parse-bmfont-ascii/-/parse-bmfont-ascii-1.0.6.tgz",
-      "integrity": "sha512-U4RrVsUFCleIOBsIGYOMKjn9PavsGOXxbvYGtMOEfnId0SVNsgehXh1DxUdVPLoxd5mvcEtvmKs2Mmf0Mpa1ZA==",
-      "peer": true
+      "integrity": "sha512-U4RrVsUFCleIOBsIGYOMKjn9PavsGOXxbvYGtMOEfnId0SVNsgehXh1DxUdVPLoxd5mvcEtvmKs2Mmf0Mpa1ZA=="
     },
     "node_modules/parse-bmfont-binary": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/parse-bmfont-binary/-/parse-bmfont-binary-1.0.6.tgz",
-      "integrity": "sha512-GxmsRea0wdGdYthjuUeWTMWPqm2+FAd4GI8vCvhgJsFnoGhTrLhXDDupwTo7rXVAgaLIGoVHDZS9p/5XbSqeWA==",
-      "peer": true
+      "integrity": "sha512-GxmsRea0wdGdYthjuUeWTMWPqm2+FAd4GI8vCvhgJsFnoGhTrLhXDDupwTo7rXVAgaLIGoVHDZS9p/5XbSqeWA=="
     },
     "node_modules/parse-bmfont-xml": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/parse-bmfont-xml/-/parse-bmfont-xml-1.1.6.tgz",
       "integrity": "sha512-0cEliVMZEhrFDwMh4SxIyVJpqYoOWDJ9P895tFuS+XuNzI5UBmBk5U5O4KuJdTnZpSBI4LFA2+ZiJaiwfSwlMA==",
-      "peer": true,
       "dependencies": {
         "xml-parse-from-string": "^1.0.0",
         "xml2js": "^0.5.0"
@@ -23920,8 +24061,7 @@
     "node_modules/parse-headers": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.6.tgz",
-      "integrity": "sha512-Tz11t3uKztEW5FEVZnj1ox8GKblWn+PvHY9TmJV5Mll2uHEwRdR/5Li1OlXoECjLYkApdhWy44ocONwXLiKO5A==",
-      "peer": true
+      "integrity": "sha512-Tz11t3uKztEW5FEVZnj1ox8GKblWn+PvHY9TmJV5Mll2uHEwRdR/5Li1OlXoECjLYkApdhWy44ocONwXLiKO5A=="
     },
     "node_modules/parse-json": {
       "version": "5.2.0",
@@ -24110,6 +24250,7 @@
       "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
       "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.9.1",
         "pg-pool": "^3.10.1",
@@ -24196,7 +24337,6 @@
       "resolved": "https://registry.npmjs.org/phin/-/phin-3.7.1.tgz",
       "integrity": "sha512-GEazpTWwTZaEQ9RhL7Nyz0WwqilbqgLahDM3D0hxWwmVDI52nXEybHqiN6/elwpkJBhcuj+WbBu+QfT0uhPGfQ==",
       "deprecated": "Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.",
-      "peer": true,
       "dependencies": {
         "centra": "^2.7.0"
       },
@@ -24992,6 +25132,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -25166,6 +25307,7 @@
       "version": "3.4.7",
       "resolved": "https://registry.npmjs.org/postgres/-/postgres-3.4.7.tgz",
       "integrity": "sha512-Jtc2612XINuBjIl/QTWsV5UvE8UHuNblcO3vVADSrKsrc6RqGX6lOW1cEo3CM2v0XG4Nat8nI+YM7/f26VxXLw==",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -25214,6 +25356,7 @@
       "resolved": "https://registry.npmjs.org/posthog-js/-/posthog-js-1.351.4.tgz",
       "integrity": "sha512-vLSYHMN31FGs1cTJ/SCW0aCLiV6K6ZW63Q1K3B16iWRBVTwz/kg6sJZi6Z/oFeKOuy9I5K/LbVLDBCaTTlcESA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/api-logs": "^0.208.0",
@@ -25307,7 +25450,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-2.0.0.tgz",
       "integrity": "sha512-ravE6m9Atw9Z/jjttRUZ+clIXogdghyZAuWJ3qEzjT+jI/dL1ifAqhZeC5VHzQp1MSt1+jxKkFNemj/iO7tVUA==",
-      "peer": true,
       "engines": {
         "node": ">=4"
       }
@@ -25317,6 +25459,7 @@
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.6.2.tgz",
       "integrity": "sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==",
       "dev": true,
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -25569,7 +25712,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/quad-indices/-/quad-indices-2.0.1.tgz",
       "integrity": "sha512-6jtmCsEbGAh5npThXrBaubbTjPcF0rMbn57XCJVI7LkW8PUT56V+uIrRCCWCn85PSgJC9v8Pm5tnJDwmOBewvA==",
-      "peer": true,
       "dependencies": {
         "an-array": "^1.0.0",
         "dtype": "^2.0.0",
@@ -25689,6 +25831,7 @@
       "version": "19.1.0",
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
       "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -25739,6 +25882,7 @@
       "version": "19.1.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
       "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.26.0"
       },
@@ -26448,73 +26592,13 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/rimraf": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-      "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-      "deprecated": "Rimraf versions prior to v4 are no longer supported",
-      "dev": true,
-      "dependencies": {
-        "glob": "^7.1.3"
-      },
-      "bin": {
-        "rimraf": "bin.js"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/rimraf/node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "node_modules/rimraf/node_modules/glob": {
-      "version": "7.2.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-      "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-      "deprecated": "Glob versions prior to v9 are no longer supported",
-      "dev": true,
-      "dependencies": {
-        "fs.realpath": "^1.0.0",
-        "inflight": "^1.0.4",
-        "inherits": "2",
-        "minimatch": "^3.1.1",
-        "once": "^1.3.0",
-        "path-is-absolute": "^1.0.0"
-      },
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/rimraf/node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/rollup": {
       "version": "4.60.1",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.1.tgz",
       "integrity": "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/estree": "1.0.8"
       },
@@ -26705,6 +26789,7 @@
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.93.2.tgz",
       "integrity": "sha512-t+YPtOQHpGW1QWsh1CHQ5cPIr9lbbGZLZnbihP/D/qZj/yuV68m8qarcV17nvkOX81BCrvzAlq2klCQFZghyTg==",
       "devOptional": true,
+      "peer": true,
       "dependencies": {
         "chokidar": "^4.0.0",
         "immutable": "^5.0.2",
@@ -26867,15 +26952,16 @@
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw=="
     },
     "node_modules/sharp": {
-      "version": "0.34.4",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.4.tgz",
-      "integrity": "sha512-FUH39xp3SBPnxWvd5iib1X8XY7J0K0X7d93sie9CJg2PO8/7gmg89Nve6OjItK53/MlAushNNxteBYfM6DEuoA==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
       "hasInstallScript": true,
+      "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "@img/colour": "^1.0.0",
-        "detect-libc": "^2.1.0",
-        "semver": "^7.7.2"
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
       },
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
@@ -26884,28 +26970,30 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-darwin-arm64": "0.34.4",
-        "@img/sharp-darwin-x64": "0.34.4",
-        "@img/sharp-libvips-darwin-arm64": "1.2.3",
-        "@img/sharp-libvips-darwin-x64": "1.2.3",
-        "@img/sharp-libvips-linux-arm": "1.2.3",
-        "@img/sharp-libvips-linux-arm64": "1.2.3",
-        "@img/sharp-libvips-linux-ppc64": "1.2.3",
-        "@img/sharp-libvips-linux-s390x": "1.2.3",
-        "@img/sharp-libvips-linux-x64": "1.2.3",
-        "@img/sharp-libvips-linuxmusl-arm64": "1.2.3",
-        "@img/sharp-libvips-linuxmusl-x64": "1.2.3",
-        "@img/sharp-linux-arm": "0.34.4",
-        "@img/sharp-linux-arm64": "0.34.4",
-        "@img/sharp-linux-ppc64": "0.34.4",
-        "@img/sharp-linux-s390x": "0.34.4",
-        "@img/sharp-linux-x64": "0.34.4",
-        "@img/sharp-linuxmusl-arm64": "0.34.4",
-        "@img/sharp-linuxmusl-x64": "0.34.4",
-        "@img/sharp-wasm32": "0.34.4",
-        "@img/sharp-win32-arm64": "0.34.4",
-        "@img/sharp-win32-ia32": "0.34.4",
-        "@img/sharp-win32-x64": "0.34.4"
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
       }
     },
     "node_modules/shebang-command": {
@@ -27273,6 +27361,7 @@
       "integrity": "sha512-6rME2tww6PFhm96iG2Xx44yzwLDWBiDWy+kJ2ub6x90werSTOiuo+tZJ94BgCfFutR0tEfLRIq59s+Zg6YyChA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@storybook/global": "^5.0.0",
         "@testing-library/jest-dom": "^6.6.3",
@@ -27816,8 +27905,7 @@
     "node_modules/super-animejs": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/super-animejs/-/super-animejs-3.1.0.tgz",
-      "integrity": "sha512-6MFAFJDRuvwkovxQZPruuyHinTa4rgj4hNLOndjcYYhZLckoXtVRY9rJPuq8p6c/tgZJrFYEAYAfJ2/hhNtUCA==",
-      "peer": true
+      "integrity": "sha512-6MFAFJDRuvwkovxQZPruuyHinTa4rgj4hNLOndjcYYhZLckoXtVRY9rJPuq8p6c/tgZJrFYEAYAfJ2/hhNtUCA=="
     },
     "node_modules/superagent": {
       "version": "10.2.3",
@@ -27881,6 +27969,7 @@
       "resolved": "https://registry.npmjs.org/svelte/-/svelte-4.2.2.tgz",
       "integrity": "sha512-My2tytF2e2NnHSpn2M7/3VdXT4JdTglYVUuSuK/mXL2XtulPYbeBfl8Dm1QiaKRn0zoULRnL+EtfZHHP0k4H3A==",
       "devOptional": true,
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.1",
         "@jridgewell/sourcemap-codec": "^1.4.15",
@@ -28100,12 +28189,6 @@
         }
       }
     },
-    "node_modules/text-table": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-      "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
-      "dev": true
-    },
     "node_modules/thenify": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/thenify/-/thenify-3.3.1.tgz",
@@ -28138,13 +28221,13 @@
     "node_modules/three": {
       "version": "0.183.2",
       "resolved": "https://registry.npmjs.org/three/-/three-0.183.2.tgz",
-      "integrity": "sha512-di3BsL2FEQ1PA7Hcvn4fyJOlxRRgFYBpMTcyOgkwJIaDOdJMebEFPA+t98EvjuljDx4hNulAGwF6KIjtwI5jgQ=="
+      "integrity": "sha512-di3BsL2FEQ1PA7Hcvn4fyJOlxRRgFYBpMTcyOgkwJIaDOdJMebEFPA+t98EvjuljDx4hNulAGwF6KIjtwI5jgQ==",
+      "peer": true
     },
     "node_modules/three-bmfont-text": {
       "version": "3.0.0",
       "resolved": "git+ssh://git@github.com/dmarcos/three-bmfont-text.git#eed4878795be9b3e38cf6aec6b903f56acd1f695",
       "integrity": "sha512-JcaccaRCcK/A4c0igPQ9RCw91cil7pLhogDVmrThEvP20B/vbFaaNlmn3frF7pWeo3lATUiNrxVfgxm9qfr9GA==",
-      "peer": true,
       "dependencies": {
         "array-shuffle": "^1.0.1",
         "layout-bmfont-text": "^1.2.0",
@@ -28312,7 +28395,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/to-readable-stream/-/to-readable-stream-1.0.0.tgz",
       "integrity": "sha512-Iq25XBt6zD5npPhlLVXGFN3/gyR2/qODcKNNyTMd4vbm39HUaOiAM4PMq0eMVC/Tkxz+Zjdsc55g9yyz+Yq00Q==",
-      "peer": true,
       "engines": {
         "node": ">=6"
       }
@@ -28321,7 +28403,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "is-number": "^7.0.0"
       },
@@ -28404,10 +28486,11 @@
       "dev": true
     },
     "node_modules/ts-api-utils": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
-      "integrity": "sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">=18.12"
       },
@@ -28833,12 +28916,37 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/typescript-eslint": {
+      "version": "8.58.1",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.58.1.tgz",
+      "integrity": "sha512-gf6/oHChByg9HJvhMO1iBexJh12AqqTfnuxscMDOVqfJW3htsdRJI/GfPpHTTcyeB8cSTUY2JcZmVgoyPqcrDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/eslint-plugin": "8.58.1",
+        "@typescript-eslint/parser": "8.58.1",
+        "@typescript-eslint/typescript-estree": "8.58.1",
+        "@typescript-eslint/utils": "8.58.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
       }
     },
     "node_modules/ufo": {
@@ -29145,7 +29253,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-3.0.0.tgz",
       "integrity": "sha512-NjFKA0DidqPa5ciFcSrXnAltTtzz84ogy+NebPvfEgAck0+TNg4UJ4IN+fB7zRZfbgUf0syOo9MDxFkDSMuFaQ==",
-      "peer": true,
       "dependencies": {
         "prepend-http": "^2.0.0"
       },
@@ -29242,7 +29349,6 @@
       "integrity": "sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "is-arguments": "^1.0.4",
@@ -29344,6 +29450,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
       "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.25.0",
         "fdir": "^6.4.4",
@@ -29490,6 +29597,7 @@
       "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
       "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.4",
@@ -29562,6 +29670,7 @@
       "resolved": "https://registry.npmjs.org/vue/-/vue-3.3.4.tgz",
       "integrity": "sha512-VTyEYn3yvIeY1Py0WaYGZsXnz3y5UnGi62GjVEqvEGPl6nxbOrCXbVOTQWBEJUqAyTUk2uJ5JLVnYJ6ZzGbrSw==",
       "devOptional": true,
+      "peer": true,
       "dependencies": {
         "@vue/compiler-dom": "3.3.4",
         "@vue/compiler-sfc": "3.3.4",
@@ -29804,8 +29913,7 @@
     "node_modules/word-wrapper": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/word-wrapper/-/word-wrapper-1.0.7.tgz",
-      "integrity": "sha512-VOPBFCm9b6FyYKQYfn9AVn2dQvdR/YOVFV6IBRA1TBMJWKffvhEX1af6FMGrttILs2Q9ikCRhLqkbY2weW6dOQ==",
-      "peer": true
+      "integrity": "sha512-VOPBFCm9b6FyYKQYfn9AVn2dQvdR/YOVFV6IBRA1TBMJWKffvhEX1af6FMGrttILs2Q9ikCRhLqkbY2weW6dOQ=="
     },
     "node_modules/wordwrap": {
       "version": "1.0.0",
@@ -29975,7 +30083,6 @@
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/xhr/-/xhr-2.6.0.tgz",
       "integrity": "sha512-/eCGLb5rxjx5e3mF1A7s+pLlR6CGyqWN91fv1JgER5mVWg1MZmlhBvy9kjcsOdRk8RrIujotWyJamfyrp+WIcA==",
-      "peer": true,
       "dependencies": {
         "global": "~4.4.0",
         "is-function": "^1.0.1",
@@ -29995,14 +30102,12 @@
     "node_modules/xml-parse-from-string": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/xml-parse-from-string/-/xml-parse-from-string-1.0.1.tgz",
-      "integrity": "sha512-ErcKwJTF54uRzzNMXq2X5sMIy88zJvfN2DmdoQvy7PAFJ+tPRU6ydWuOKNMyfmOjdyBQTFREi60s0Y0SyI0G0g==",
-      "peer": true
+      "integrity": "sha512-ErcKwJTF54uRzzNMXq2X5sMIy88zJvfN2DmdoQvy7PAFJ+tPRU6ydWuOKNMyfmOjdyBQTFREi60s0Y0SyI0G0g=="
     },
     "node_modules/xml2js": {
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
       "integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
-      "peer": true,
       "dependencies": {
         "sax": ">=0.6.0",
         "xmlbuilder": "~11.0.0"
@@ -30015,7 +30120,6 @@
       "version": "11.0.1",
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
       "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
-      "peer": true,
       "engines": {
         "node": ">=4.0"
       }
@@ -30187,8 +30291,22 @@
       "version": "3.25.76",
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-validation-error": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/zod-validation-error/-/zod-validation-error-4.0.2.tgz",
+      "integrity": "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
       }
     },
     "node_modules/zwitch": {
@@ -30277,7 +30395,7 @@
         "@mantine/notifications": "8.3.1",
         "@mdx-js/loader": "^3.1.1",
         "@mdx-js/react": "^3.1.1",
-        "@next/mdx": "^15.5.4",
+        "@next/mdx": "16.2.3",
         "@semble/types": "*",
         "@tanstack/react-query": "^5.85.5",
         "@types/mdx": "^2.0.13",
@@ -30285,9 +30403,9 @@
         "capnweb": "^0.6.1",
         "date-fns": "^4.1.0",
         "dayjs": "^1.11.13",
-        "next": "^15.4.10",
-        "react": "19.1.0",
-        "react-dom": "19.1.0",
+        "next": "16.2.3",
+        "react": "19.2.5",
+        "react-dom": "19.2.5",
         "react-error-boundary": "^6.0.0",
         "react-force-graph": "^1.48.2",
         "react-force-graph-2d": "^1.29.1",
@@ -30303,12 +30421,12 @@
         "@storybook/nextjs-vite": "^9.1.2",
         "@types/chrome": "^0.0.332",
         "@types/node": "^20.10.4",
-        "@types/react": "19.1.8",
-        "@types/react-dom": "19.1.6",
+        "@types/react": "19.2.14",
+        "@types/react-dom": "19.2.3",
         "@vitest/coverage-v8": "^3.2.4",
         "autoprefixer": "^10.4.16",
-        "eslint": "^8.55.0",
-        "eslint-config-next": "15.4.1",
+        "eslint": "^9.0.0",
+        "eslint-config-next": "16.2.3",
         "plasmo": "^0.90.5",
         "postcss": "^8.5.6",
         "postcss-preset-mantine": "^1.18.0",
@@ -30318,38 +30436,6 @@
         "typescript": "^5.3.3",
         "vite": "^6.3.5",
         "vitest": "^3.2.4"
-      }
-    },
-    "src/webapp/node_modules/@eslint/eslintrc": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
-      "integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
-      "dev": true,
-      "dependencies": {
-        "ajv": "^6.12.4",
-        "debug": "^4.3.2",
-        "espree": "^9.6.0",
-        "globals": "^13.19.0",
-        "ignore": "^5.2.0",
-        "import-fresh": "^3.2.1",
-        "js-yaml": "^4.1.0",
-        "minimatch": "^3.1.2",
-        "strip-json-comments": "^3.1.1"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "src/webapp/node_modules/@eslint/js": {
-      "version": "8.57.1",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.57.1.tgz",
-      "integrity": "sha512-d9zaMRSTIKDLhctzH12MtXvJKSSUhaHcjV+2Z+GK+EEY7XKpP5yR4x+N3TAcHTcu963nIr+TMcCb4DBCYX1z6Q==",
-      "dev": true,
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
     "src/webapp/node_modules/@mantine/code-highlight": {
@@ -30370,6 +30456,7 @@
       "version": "8.3.1",
       "resolved": "https://registry.npmjs.org/@mantine/core/-/core-8.3.1.tgz",
       "integrity": "sha512-OYfxn9cTv+K6RZ8+Ozn/HDQXkB8Fmn+KJJt5lxyFDP9F09EHnC59Ldadv1LyUZVBGtNqz4sn6b3vBShbxwAmYw==",
+      "peer": true,
       "dependencies": {
         "@floating-ui/react": "^0.27.16",
         "clsx": "^2.1.1",
@@ -30440,6 +30527,7 @@
       "version": "8.3.1",
       "resolved": "https://registry.npmjs.org/@mantine/hooks/-/hooks-8.3.1.tgz",
       "integrity": "sha512-lQutBS+Q0iz/cNFvdrsYassPWo3RtWcmDGJeOtKfHigLzFOhxUuLOkQgepDbMf3WcVMB/tist6Px1PQOv57JTw==",
+      "peer": true,
       "peerDependencies": {
         "react": "^18.x || ^19.x"
       }
@@ -30478,277 +30566,249 @@
         "react": "^18.x || ^19.x"
       }
     },
-    "src/webapp/node_modules/ansi-regex": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
+    "src/webapp/node_modules/@next/env": {
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.3.tgz",
+      "integrity": "sha512-ZWXyj4uNu4GCWQw9cjRxWlbD+33mcDszIo9iQxFnBX3Wmgq9ulaSJcl6VhuWx5pCWqqD+9W6Wfz7N0lM5lYPMA==",
+      "license": "MIT"
+    },
+    "src/webapp/node_modules/@next/swc-darwin-arm64": {
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.3.tgz",
+      "integrity": "sha512-u37KDKTKQ+OQLvY+z7SNXixwo4Q2/IAJFDzU1fYe66IbCE51aDSAzkNDkWmLN0yjTUh4BKBd+hb69jYn6qqqSg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
       "engines": {
-        "node": ">=8"
+        "node": ">= 10"
       }
     },
-    "src/webapp/node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
-      "dev": true,
+    "src/webapp/node_modules/@next/swc-darwin-x64": {
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.3.tgz",
+      "integrity": "sha512-gHjL/qy6Q6CG3176FWbAKyKh9IfntKZTB3RY/YOJdDFpHGsUDXVH38U4mMNpHVGXmeYW4wj22dMp1lTfmu/bTQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "src/webapp/node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.3.tgz",
+      "integrity": "sha512-U6vtblPtU/P14Y/b/n9ZY0GOxbbIhTFuaFR7F4/uMBidCi2nSdaOFhA0Go81L61Zd6527+yvuX44T4ksnf8T+Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "src/webapp/node_modules/@next/swc-linux-arm64-musl": {
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.3.tgz",
+      "integrity": "sha512-/YV0LgjHUmfhQpn9bVoGc4x4nan64pkhWR5wyEV8yCOfwwrH630KpvRg86olQHTwHIn1z59uh6JwKvHq1h4QEw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "src/webapp/node_modules/@next/swc-linux-x64-gnu": {
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.3.tgz",
+      "integrity": "sha512-/HiWEcp+WMZ7VajuiMEFGZ6cg0+aYZPqCJD3YJEfpVWQsKYSjXQG06vJP6F1rdA03COD9Fef4aODs3YxKx+RDQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "src/webapp/node_modules/@next/swc-linux-x64-musl": {
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.3.tgz",
+      "integrity": "sha512-Kt44hGJfZSefebhk/7nIdivoDr3Ugp5+oNz9VvF3GUtfxutucUIHfIO0ZYO8QlOPDQloUVQn4NVC/9JvHRk9hw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "src/webapp/node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.3.tgz",
+      "integrity": "sha512-O2NZ9ie3Tq6xj5Z5CSwBT3+aWAMW2PIZ4egUi9MaWLkwaehgtB7YZjPm+UpcNpKOme0IQuqDcor7BsW6QBiQBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "src/webapp/node_modules/@next/swc-win32-x64-msvc": {
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.3.tgz",
+      "integrity": "sha512-Ibm29/GgB/ab5n7XKqlStkm54qqZE8v2FnijUPBgrd67FWrac45o/RsNlaOWjme/B5UqeWt/8KM4aWBwA1D2Kw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "src/webapp/node_modules/next": {
+      "version": "16.2.3",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.2.3.tgz",
+      "integrity": "sha512-9V3zV4oZFza3PVev5/poB9g0dEafVcgNyQ8eTRop8GvxZjV2G15FC5ARuG1eFD42QgeYkzJBJzHghNP8Ad9xtA==",
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
-      }
-    },
-    "src/webapp/node_modules/doctrine": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
-      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
-      "dev": true,
-      "dependencies": {
-        "esutils": "^2.0.2"
-      },
-      "engines": {
-        "node": ">=6.0.0"
-      }
-    },
-    "src/webapp/node_modules/eslint": {
-      "version": "8.57.1",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
-      "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
-      "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
-      "dev": true,
-      "dependencies": {
-        "@eslint-community/eslint-utils": "^4.2.0",
-        "@eslint-community/regexpp": "^4.6.1",
-        "@eslint/eslintrc": "^2.1.4",
-        "@eslint/js": "8.57.1",
-        "@humanwhocodes/config-array": "^0.13.0",
-        "@humanwhocodes/module-importer": "^1.0.1",
-        "@nodelib/fs.walk": "^1.2.8",
-        "@ungap/structured-clone": "^1.2.0",
-        "ajv": "^6.12.4",
-        "chalk": "^4.0.0",
-        "cross-spawn": "^7.0.2",
-        "debug": "^4.3.2",
-        "doctrine": "^3.0.0",
-        "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^7.2.2",
-        "eslint-visitor-keys": "^3.4.3",
-        "espree": "^9.6.1",
-        "esquery": "^1.4.2",
-        "esutils": "^2.0.2",
-        "fast-deep-equal": "^3.1.3",
-        "file-entry-cache": "^6.0.1",
-        "find-up": "^5.0.0",
-        "glob-parent": "^6.0.2",
-        "globals": "^13.19.0",
-        "graphemer": "^1.4.0",
-        "ignore": "^5.2.0",
-        "imurmurhash": "^0.1.4",
-        "is-glob": "^4.0.0",
-        "is-path-inside": "^3.0.3",
-        "js-yaml": "^4.1.0",
-        "json-stable-stringify-without-jsonify": "^1.0.1",
-        "levn": "^0.4.1",
-        "lodash.merge": "^4.6.2",
-        "minimatch": "^3.1.2",
-        "natural-compare": "^1.4.0",
-        "optionator": "^0.9.3",
-        "strip-ansi": "^6.0.1",
-        "text-table": "^0.2.0"
+        "@next/env": "16.2.3",
+        "@swc/helpers": "0.5.15",
+        "baseline-browser-mapping": "^2.9.19",
+        "caniuse-lite": "^1.0.30001579",
+        "postcss": "8.4.31",
+        "styled-jsx": "5.1.6"
       },
       "bin": {
-        "eslint": "bin/eslint.js"
+        "next": "dist/bin/next"
       },
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+        "node": ">=20.9.0"
       },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
+      "optionalDependencies": {
+        "@next/swc-darwin-arm64": "16.2.3",
+        "@next/swc-darwin-x64": "16.2.3",
+        "@next/swc-linux-arm64-gnu": "16.2.3",
+        "@next/swc-linux-arm64-musl": "16.2.3",
+        "@next/swc-linux-x64-gnu": "16.2.3",
+        "@next/swc-linux-x64-musl": "16.2.3",
+        "@next/swc-win32-arm64-msvc": "16.2.3",
+        "@next/swc-win32-x64-msvc": "16.2.3",
+        "sharp": "^0.34.5"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.1.0",
+        "@playwright/test": "^1.51.1",
+        "babel-plugin-react-compiler": "*",
+        "react": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0",
+        "react-dom": "^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0",
+        "sass": "^1.3.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@playwright/test": {
+          "optional": true
+        },
+        "babel-plugin-react-compiler": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        }
       }
     },
-    "src/webapp/node_modules/eslint-scope": {
-      "version": "7.2.2",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
-      "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
-      "dev": true,
+    "src/webapp/node_modules/next/node_modules/postcss": {
+      "version": "8.4.31",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
+      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
       "dependencies": {
-        "esrecurse": "^4.3.0",
-        "estraverse": "^5.2.0"
+        "nanoid": "^3.3.6",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
       },
       "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
+        "node": "^10 || ^12 || >=14"
       }
     },
-    "src/webapp/node_modules/espree": {
-      "version": "9.6.1",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
-      "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
-      "dev": true,
+    "src/webapp/node_modules/react": {
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.5.tgz",
+      "integrity": "sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "src/webapp/node_modules/react-dom": {
+      "version": "19.2.5",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.5.tgz",
+      "integrity": "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==",
+      "license": "MIT",
+      "peer": true,
       "dependencies": {
-        "acorn": "^8.9.0",
-        "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^3.4.1"
+        "scheduler": "^0.27.0"
       },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
+      "peerDependencies": {
+        "react": "^19.2.5"
       }
     },
-    "src/webapp/node_modules/file-entry-cache": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
-      "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
-      "dev": true,
-      "dependencies": {
-        "flat-cache": "^3.0.4"
-      },
-      "engines": {
-        "node": "^10.12.0 || >=12.0.0"
-      }
-    },
-    "src/webapp/node_modules/find-up": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
-      "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
-      "dev": true,
-      "dependencies": {
-        "locate-path": "^6.0.0",
-        "path-exists": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "src/webapp/node_modules/flat-cache": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.2.0.tgz",
-      "integrity": "sha512-CYcENa+FtcUKLmhhqyctpclsq7QF38pKjZHsGNiSQF5r4FtoKDWabFDl3hzaEQMvT1LHEysw5twgLvpYYb4vbw==",
-      "dev": true,
-      "dependencies": {
-        "flatted": "^3.2.9",
-        "keyv": "^4.5.3",
-        "rimraf": "^3.0.2"
-      },
-      "engines": {
-        "node": "^10.12.0 || >=12.0.0"
-      }
-    },
-    "src/webapp/node_modules/globals": {
-      "version": "13.24.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
-      "integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
-      "dev": true,
-      "dependencies": {
-        "type-fest": "^0.20.2"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "src/webapp/node_modules/ignore": {
-      "version": "5.3.2",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
-      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
-      "dev": true,
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "src/webapp/node_modules/is-path-inside": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
-      "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "src/webapp/node_modules/locate-path": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
-      "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-      "dev": true,
-      "dependencies": {
-        "p-locate": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "src/webapp/node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "src/webapp/node_modules/p-locate": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-      "dev": true,
-      "dependencies": {
-        "p-limit": "^3.0.2"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "src/webapp/node_modules/path-exists": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
-      "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "src/webapp/node_modules/strip-ansi": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
-      "dependencies": {
-        "ansi-regex": "^5.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "src/webapp/node_modules/type-fest": {
-      "version": "0.20.2",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-      "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
+    "src/webapp/node_modules/scheduler": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
+      "license": "MIT"
     }
   }
 }

--- a/src/webapp/app/(auth)/login/layout.tsx
+++ b/src/webapp/app/(auth)/login/layout.tsx
@@ -13,9 +13,10 @@ import {
   PopoverDropdown,
 } from '@mantine/core';
 import { Metadata } from 'next';
-import Link from 'next/link';
+
 import { IoMdHelpCircleOutline } from 'react-icons/io';
 import SembleLogo from '@/assets/semble-logo.svg';
+
 
 export const metadata: Metadata = {
   title: 'Log in — Semble',
@@ -82,7 +83,6 @@ export default async function Layout(props: Props) {
             <Text fw={500} fz={'sm'} ta={'center'} c={'dark.1'}>
               By continuing, you agree to our{' '}
               <Anchor
-                component={Link}
                 href={'/privacy-policy'}
                 c="dark.1"
                 fw={600}

--- a/src/webapp/app/(auth)/login/layout.tsx
+++ b/src/webapp/app/(auth)/login/layout.tsx
@@ -17,7 +17,6 @@ import { Metadata } from 'next';
 import { IoMdHelpCircleOutline } from 'react-icons/io';
 import SembleLogo from '@/assets/semble-logo.svg';
 
-
 export const metadata: Metadata = {
   title: 'Log in — Semble',
   description: 'Welcome back',

--- a/src/webapp/app/(auth)/privacy-policy/layout.tsx
+++ b/src/webapp/app/(auth)/privacy-policy/layout.tsx
@@ -1,15 +1,7 @@
-import {
-  Container,
-  Stack,
-  Image,
-  Anchor,
-  Box,
-  Button,
-  Badge,
-} from '@mantine/core';
+import { Container, Stack, Image, Anchor, Box, Badge } from '@mantine/core';
 import SembleLogo from '@/assets/semble-logo.svg';
 import { Metadata } from 'next';
-import Link from 'next/link';
+import { LinkButton } from '@/components/link/MantineLink';
 
 export const metadata: Metadata = {
   title: 'Privacy Policy — Semble',
@@ -24,7 +16,7 @@ export default function Layout(props: Props) {
   return (
     <Container p="md" size="sm">
       <Stack align="start">
-        <Anchor component={Link} href={'/'}>
+        <Anchor href={'/'}>
           <Stack align="center" gap={'xs'}>
             <Image src={SembleLogo.src} alt="Semble logo" w={'auto'} h={50} />
             <Badge size="sm">Alpha</Badge>
@@ -33,15 +25,9 @@ export default function Layout(props: Props) {
 
         <Stack>{props.children}</Stack>
         <Box component="footer" px={'md'} py={'xs'} mt={'xl'} mx={'auto'}>
-          <Button
-            component={Link}
-            href="/"
-            variant="light"
-            color="dark.1"
-            fw={600}
-          >
+          <LinkButton href="/" variant="light" color="dark.1" fw={600}>
             Back to home
-          </Button>
+          </LinkButton>
         </Box>
       </Stack>
     </Container>

--- a/src/webapp/app/(dashboard)/error.tsx
+++ b/src/webapp/app/(dashboard)/error.tsx
@@ -8,14 +8,13 @@ import {
   Badge,
   Text,
   Group,
-  Button,
   Container,
 } from '@mantine/core';
 import SembleLogo from '@/assets/semble-logo.svg';
 import BG from '@/assets/semble-bg.webp';
 import DarkBG from '@/assets/semble-bg-dark.png';
-import Link from 'next/link';
 import { BiRightArrowAlt } from 'react-icons/bi';
+import { LinkButton } from '@/components/link/MantineLink';
 
 export default function Error() {
   return (
@@ -80,19 +79,18 @@ function Content() {
           </Stack>
 
           <Group justify="center" gap="md" mt={'lg'}>
-            <Button component={Link} href="/signup" size="lg">
+            <LinkButton href="/signup" size="lg">
               Sign up
-            </Button>
+            </LinkButton>
 
-            <Button
-              component={Link}
+            <LinkButton
               href="/login"
               size="lg"
               color="var(--mantine-color-dark-filled)"
               rightSection={<BiRightArrowAlt size={22} />}
             >
               Log in
-            </Button>
+            </LinkButton>
           </Group>
         </Stack>
       </Container>

--- a/src/webapp/app/(dashboard)/profile/[handle]/(withHeader)/cards/page.tsx
+++ b/src/webapp/app/(dashboard)/profile/[handle]/(withHeader)/cards/page.tsx
@@ -1,6 +1,5 @@
 import CardsContainer from '@/features/cards/containers/cardsContainer/CardsContainer';
-import { Group, Button, Container } from '@mantine/core';
-import Link from 'next/link';
+import { Group, Container } from '@mantine/core';
 import { IoSearch } from 'react-icons/io5';
 import {
   CardFiltersRoot,
@@ -10,6 +9,7 @@ import {
 } from '@/features/cards/components/cardFilters/CardFilters';
 import { CardSortField, UrlType } from '@semble/types';
 import { Fragment } from 'react';
+import { LinkButton } from '@/components/link/MantineLink';
 
 interface Props {
   params: Promise<{ handle: string }>;
@@ -36,15 +36,14 @@ export default async function Page(props: Props) {
             <CardFiltersViewToggle />
             <CardFiltersTypeFilter />
           </CardFiltersRoot>
-          <Button
-            component={Link}
+          <LinkButton
             href={`/search/cards?handle=${handle}`}
             variant="light"
             color="gray"
             rightSection={<IoSearch />}
           >
             Search
-          </Button>
+          </LinkButton>
         </Group>
       </Container>
       <CardsContainer handle={handle} key={suspenseKey} />

--- a/src/webapp/app/(dashboard)/profile/[handle]/(withHeader)/collections/page.tsx
+++ b/src/webapp/app/(dashboard)/profile/[handle]/(withHeader)/collections/page.tsx
@@ -1,6 +1,5 @@
 import CollectionsContainer from '@/features/collections/containers/collectionsContainer/CollectionsContainer';
-import { Group, Button, Container } from '@mantine/core';
-import Link from 'next/link';
+import { Group, Container } from '@mantine/core';
 import { IoSearch } from 'react-icons/io5';
 import {
   CollectionFiltersRoot,
@@ -9,6 +8,7 @@ import {
 } from '@/features/collections/components/collectionFilters/CollectionFilters';
 import { Fragment } from 'react';
 import { CollectionSortField } from '@semble/types';
+import { LinkButton } from '@/components/link/MantineLink';
 
 interface Props {
   params: Promise<{ handle: string }>;
@@ -32,15 +32,14 @@ export default async function Page(props: Props) {
             <CollectionFiltersSortSelect />
             <CollectionFiltersViewToggle />
           </CollectionFiltersRoot>
-          <Button
-            component={Link}
+          <LinkButton
             href={`/search/collections?handle=${handle}`}
             variant="light"
             color="gray"
             rightSection={<IoSearch />}
           >
             Search
-          </Button>
+          </LinkButton>
         </Group>
       </Container>
       <CollectionsContainer handle={handle} key={sort} />

--- a/src/webapp/app/bookmarklet/page.tsx
+++ b/src/webapp/app/bookmarklet/page.tsx
@@ -16,7 +16,7 @@ import {
   CopyButton,
 } from '@mantine/core';
 import SembleLogo from '@/assets/semble-logo.svg';
-import Link from 'next/link';
+
 
 export default function BookmarkletPage() {
   const appUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://127.0.0.1:4000';
@@ -39,7 +39,7 @@ export default function BookmarkletPage() {
       <Stack gap="xl">
         <Stack gap="xs" align="center">
           <Stack align="center" gap={'xs'}>
-            <Anchor component={Link} href={'/'}>
+            <Anchor href={'/'}>
               <Image
                 src={SembleLogo.src}
                 alt="Semble logo"

--- a/src/webapp/app/bookmarklet/page.tsx
+++ b/src/webapp/app/bookmarklet/page.tsx
@@ -17,7 +17,6 @@ import {
 } from '@mantine/core';
 import SembleLogo from '@/assets/semble-logo.svg';
 
-
 export default function BookmarkletPage() {
   const appUrl = process.env.NEXT_PUBLIC_APP_URL || 'http://127.0.0.1:4000';
 

--- a/src/webapp/app/page.tsx
+++ b/src/webapp/app/page.tsx
@@ -5,14 +5,12 @@ import {
   BackgroundImage,
   Title,
   Stack,
-  Button,
   Container,
   Box,
   Center,
   Group,
   Badge,
 } from '@mantine/core';
-import Link from 'next/link';
 import BG from '@/assets/semble-bg.webp';
 import DarkBG from '@/assets/semble-bg-dark.png';
 import CurateIcon from '@/assets/icons/curate-icon.svg';
@@ -28,6 +26,7 @@ import { Fragment, Suspense } from 'react';
 import AuthButtons from '@/components/landing/authButtons/AuthButtons';
 import { IoArrowForward } from 'react-icons/io5';
 import NavMenu from '@/components/landing/navMenu/NavMenu';
+import { LinkButton } from '@/components/link/MantineLink';
 
 export default async function Page() {
   const fadeStyle = {
@@ -82,8 +81,7 @@ function Content() {
         <Container size="xl" p="sm" my="auto">
           <Stack gap="5rem" align="center">
             <Stack gap="xs" align="center" maw={700}>
-              <Button
-                component={Link}
+              <LinkButton
                 href={'https://atmosphereconf.org/event/OD6Gd0A'}
                 size="compact-sm"
                 leftSection={'🪿'}
@@ -93,7 +91,7 @@ function Content() {
                 bg={'blue.0'}
               >
                 Watch our talk at ATmosphereConf!
-              </Button>
+              </LinkButton>
               <AnimatedTitle />
 
               {/* light mode subtitle */}

--- a/src/webapp/components/contentDisplay/richTextRenderer/RichTextRenderer.tsx
+++ b/src/webapp/components/contentDisplay/richTextRenderer/RichTextRenderer.tsx
@@ -5,7 +5,6 @@ import { RichText } from '@atproto/api';
 import { Anchor, AnchorProps, Text, TextProps } from '@mantine/core';
 import { getDomain } from '@/lib/utils/link';
 
-
 interface Props {
   text: string;
   linkProps?: Partial<AnchorProps>; // for mentions, links, hashtags

--- a/src/webapp/components/contentDisplay/richTextRenderer/RichTextRenderer.tsx
+++ b/src/webapp/components/contentDisplay/richTextRenderer/RichTextRenderer.tsx
@@ -1,9 +1,10 @@
 'use client';
 
 import { RichText } from '@atproto/api';
-import Link from 'next/link';
+
 import { Anchor, AnchorProps, Text, TextProps } from '@mantine/core';
 import { getDomain } from '@/lib/utils/link';
+
 
 interface Props {
   text: string;
@@ -34,7 +35,6 @@ export default function RichTextRenderer({
           return (
             <Anchor
               key={`mention-${i}`}
-              component={Link}
               href={`/profile/${segment.text.slice(1)}`}
               c={linkProps.c || 'blue'}
               fw={linkProps.fw || 500}
@@ -69,7 +69,6 @@ export default function RichTextRenderer({
           return (
             <Anchor
               key={`tag-${i}`}
-              component={Link}
               c={linkProps.c || 'blue'}
               fw={linkProps.fw || 500}
               href={`https://bsky.app/hashtag/${encodedTag}`}

--- a/src/webapp/components/landing/activityCard/ActivityCard.tsx
+++ b/src/webapp/components/landing/activityCard/ActivityCard.tsx
@@ -2,14 +2,14 @@
 
 import UrlCardContent from '@/features/cards/components/urlCardContent/UrlCardContent';
 import { isCollectionPage, isProfilePage } from '@/lib/utils/link';
-import { Avatar, Card, Group, Stack, Text } from '@mantine/core';
+import { Card, Group, Stack, Text } from '@mantine/core';
 import { UrlCard, User } from '@semble/types';
 import { MouseEvent, Suspense } from 'react';
 import { useRouter } from 'next/navigation';
-import Link from 'next/link';
 import { sanitizeText } from '@/lib/utils/text';
 import { getRelativeTime } from '@/lib/utils/time';
 import UrlCardContentSkeleton from '@/features/cards/components/urlCardContent/Skeleton.UrlCardContent';
+import { LinkAvatar, LinkText } from '@/components/link/MantineLink';
 
 interface Props {
   id: string;
@@ -50,8 +50,7 @@ export default function ActivityCard(props: Props) {
             align="center"
           >
             <Group gap={'xs'}>
-              <Avatar
-                component={Link}
+              <LinkAvatar
                 href={`/profile/${props.cardAuthor.handle}`}
                 src={props.cardAuthor.avatarUrl?.replace(
                   'avatar',
@@ -60,14 +59,13 @@ export default function ActivityCard(props: Props) {
                 alt={`${props.cardAuthor.name}'s avatar`}
                 size={'sm'}
               />
-              <Text
-                component={Link}
+              <LinkText
                 href={`/profile/${props.cardAuthor.handle}`}
                 fw={600}
                 c={'bright'}
               >
                 {sanitizeText(props.cardAuthor.name)}
-              </Text>
+              </LinkText>
             </Group>
             <Text fz={'sm'} fw={600} c={'gray'} span display={'block'}>
               {time}

--- a/src/webapp/components/landing/authButtons/AuthButtons.tsx
+++ b/src/webapp/components/landing/authButtons/AuthButtons.tsx
@@ -1,9 +1,9 @@
 'use client';
 
 import { useAuth } from '@/hooks/useAuth';
-import { Avatar, Box, Button, Group } from '@mantine/core';
-import Link from 'next/link';
+import { Avatar, Box, Group } from '@mantine/core';
 import { BiRightArrowAlt } from 'react-icons/bi';
+import { LinkButton } from '@/components/link/MantineLink';
 
 export default function AuthButtons() {
   const { user, isLoading } = useAuth();
@@ -11,8 +11,7 @@ export default function AuthButtons() {
   return (
     <Box mt={'lg'}>
       {!isLoading && user ? (
-        <Button
-          component={Link}
+        <LinkButton
           href="/home"
           size="lg"
           color="var(--mantine-color-dark-filled)"
@@ -26,7 +25,7 @@ export default function AuthButtons() {
           rightSection={<BiRightArrowAlt size={22} />}
         >
           @{user?.handle}
-        </Button>
+        </LinkButton>
       ) : (
         <UnauthenticatedButtons />
       )}
@@ -37,19 +36,18 @@ export default function AuthButtons() {
 function UnauthenticatedButtons() {
   return (
     <Group gap="md">
-      <Button component={Link} href="/signup" size="lg">
+      <LinkButton href="/signup" size="lg">
         Sign up
-      </Button>
+      </LinkButton>
 
-      <Button
-        component={Link}
+      <LinkButton
         href="/login"
         size="lg"
         color="var(--mantine-color-dark-filled)"
         rightSection={<BiRightArrowAlt size={22} />}
       >
         Log in
-      </Button>
+      </LinkButton>
     </Group>
   );
 }

--- a/src/webapp/components/landing/navMenu/NavMenu.tsx
+++ b/src/webapp/components/landing/navMenu/NavMenu.tsx
@@ -1,9 +1,8 @@
 'use client';
 
-import { Box, Group, Button, ScrollAreaAutosize } from '@mantine/core';
+import { Group, Button, ScrollAreaAutosize } from '@mantine/core';
 import { useDisclosure, useOs } from '@mantine/hooks';
-import Link from 'next/link';
-import { RiArrowRightUpLine } from 'react-icons/ri';
+import { LinkButton } from '@/components/link/MantineLink';
 
 const IOS_SHORTCUT_HREF =
   'https://www.icloud.com/shortcuts/9c4b4b4bc4ef4d6d93513c59373b0af6';
@@ -29,8 +28,7 @@ export default function NavMenu() {
         </Button>
 
         {isIos && (
-          <Button
-            component={Link}
+          <LinkButton
             href={IOS_SHORTCUT_HREF}
             target="_blank"
             variant="light"
@@ -38,7 +36,7 @@ export default function NavMenu() {
             size="xs"
           >
             iOS shortcut
-          </Button>
+          </LinkButton>
         )}
       </Group>
     </ScrollAreaAutosize>

--- a/src/webapp/components/landing/recentActivity/RecentActivity.tsx
+++ b/src/webapp/components/landing/recentActivity/RecentActivity.tsx
@@ -1,18 +1,11 @@
 import { getUrlCards } from '@/features/cards/lib/dal';
-import {
-  Button,
-  Card,
-  Group,
-  ScrollAreaAutosize,
-  Stack,
-  Text,
-} from '@mantine/core';
-import Link from 'next/link';
+import { Card, Group, ScrollAreaAutosize, Stack, Text } from '@mantine/core';
 import { BiRightArrowAlt } from 'react-icons/bi';
 import ActivityCard from '../activityCard/ActivityCard';
 import ActivityCardSkeleton from '../activityCard/Skeleton.ActivityCard';
 import { Suspense } from 'react';
 import { unstable_cache } from 'next/cache';
+import { LinkButton } from '@/components/link/MantineLink';
 
 const getRecentActivity = unstable_cache(
   async () => {
@@ -57,15 +50,14 @@ export default async function RecentActivity() {
           <Text fz="xl" fw={600}>
             Highlights from our community
           </Text>
-          <Button
-            component={Link}
+          <LinkButton
             href="/explore"
             variant="light"
             color="gray"
             rightSection={<BiRightArrowAlt size={20} />}
           >
             Explore
-          </Button>
+          </LinkButton>
         </Group>
 
         <ScrollAreaAutosize type="auto" mah={{ base: 250, xs: 400 }}>

--- a/src/webapp/components/link/MantineLink.tsx
+++ b/src/webapp/components/link/MantineLink.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import {
+  ActionIcon,
+  type ActionIconProps,
+  Avatar,
+  type AvatarProps,
+  Badge,
+  type BadgeProps,
+  Button,
+  type ButtonProps,
+  Card,
+  type CardProps,
+  MenuItem,
+  type MenuItemProps,
+  NavLink,
+  type NavLinkProps,
+  type PolymorphicComponentProps,
+  Text,
+  type TextProps,
+} from '@mantine/core';
+import NextLink from 'next/link';
+
+type AsNextLink<P> = PolymorphicComponentProps<typeof NextLink, P>;
+
+export function LinkActionIcon(props: AsNextLink<ActionIconProps>) {
+  return <ActionIcon component={NextLink} {...props} />;
+}
+
+export function LinkAvatar(props: AsNextLink<AvatarProps>) {
+  return <Avatar component={NextLink} {...props} />;
+}
+
+export function LinkBadge(props: AsNextLink<BadgeProps>) {
+  return <Badge component={NextLink} {...props} />;
+}
+
+export function LinkButton(props: AsNextLink<ButtonProps>) {
+  return <Button component={NextLink} {...props} />;
+}
+
+export function LinkCard(props: AsNextLink<CardProps>) {
+  return <Card component={NextLink} {...props} />;
+}
+
+export function LinkMenuItem(props: AsNextLink<MenuItemProps>) {
+  return <MenuItem component={NextLink} {...props} />;
+}
+
+export function LinkNavLink(props: AsNextLink<NavLinkProps>) {
+  return <NavLink component={NextLink} {...props} />;
+}
+
+export function LinkText(props: AsNextLink<TextProps>) {
+  return <Text component={NextLink} {...props} />;
+}

--- a/src/webapp/components/navigation/bottomBarItem/BottomBarItem.tsx
+++ b/src/webapp/components/navigation/bottomBarItem/BottomBarItem.tsx
@@ -8,7 +8,6 @@ import { usePathname } from 'next/navigation';
 import { useNavbarContext } from '@/providers/navbar';
 import { useWebHaptics } from 'web-haptics/react';
 
-
 interface Props {
   href: string;
   title?: string;

--- a/src/webapp/components/navigation/bottomBarItem/BottomBarItem.tsx
+++ b/src/webapp/components/navigation/bottomBarItem/BottomBarItem.tsx
@@ -2,11 +2,12 @@
 
 import { IconType } from 'react-icons/lib';
 import { ActionIcon, Anchor, Stack, Text } from '@mantine/core';
-import Link from 'next/link';
+
 import { ReactElement, isValidElement } from 'react';
 import { usePathname } from 'next/navigation';
 import { useNavbarContext } from '@/providers/navbar';
 import { useWebHaptics } from 'web-haptics/react';
+
 
 interface Props {
   href: string;
@@ -31,7 +32,6 @@ export default function BottomBarItem(props: Props) {
 
   return (
     <Anchor
-      component={Link}
       href={props.href}
       underline="never"
       onClick={() => {

--- a/src/webapp/components/navigation/guestNavbar/GuestNavbar.tsx
+++ b/src/webapp/components/navigation/guestNavbar/GuestNavbar.tsx
@@ -9,20 +9,19 @@ import {
   Image,
   Box,
   Badge,
-  Button,
   Text,
 } from '@mantine/core';
 import { MdOutlineEmojiNature } from 'react-icons/md';
-import Link from 'next/link';
 import SembleLogo from '@/assets/semble-logo.svg';
 import NavbarToggle from '../NavbarToggle';
 import { BiRightArrowAlt, BiSearch } from 'react-icons/bi';
+import { LinkButton } from '@/components/link/MantineLink';
 
 export default function GuestNavbar() {
   return (
     <AppShellNavbar p={'xs'} style={{ zIndex: 3 }}>
       <Group justify="space-between">
-        <Anchor component={Link} href={'/home'} mx={2}>
+        <Anchor href={'/home'} mx={2}>
           <Stack align="center" gap={6}>
             <Image src={SembleLogo.src} alt="Semble logo" w={20.84} h={28} />
             <Badge size="xs">Alpha</Badge>
@@ -40,17 +39,14 @@ export default function GuestNavbar() {
               A social knowledge network for research
             </Text>
             <Group grow>
-              <Button component={Link} href="/signup">
-                Sign up
-              </Button>
-              <Button
-                component={Link}
+              <LinkButton href="/signup">Sign up</LinkButton>
+              <LinkButton
                 href="/login"
                 color="var(--mantine-color-dark-filled)"
                 rightSection={<BiRightArrowAlt size={22} />}
               >
                 Log in
-              </Button>
+              </LinkButton>
             </Group>
 
             <Stack gap={5}>

--- a/src/webapp/components/navigation/navItem/NavItem.tsx
+++ b/src/webapp/components/navigation/navItem/NavItem.tsx
@@ -1,9 +1,8 @@
 'use client';
 
 import { useNavbarContext } from '@/providers/navbar';
-import { NavLink } from '@mantine/core';
-import Link from 'next/link';
 import { usePathname } from 'next/navigation';
+import { LinkNavLink } from '@/components/link/MantineLink';
 
 interface Props {
   href: string;
@@ -17,8 +16,7 @@ export default function NavItem(props: Props) {
   const isActive = pathname === props.href;
 
   return (
-    <NavLink
-      component={Link}
+    <LinkNavLink
       href={props.href}
       color="gray"
       c={'gray'}

--- a/src/webapp/components/navigation/navbar/Navbar.tsx
+++ b/src/webapp/components/navigation/navbar/Navbar.tsx
@@ -32,7 +32,6 @@ import { track } from '@vercel/analytics';
 import NotificationNavItem from '@/features/notifications/components/notificationNavItem/NotificationNavItem';
 import Composer from '@/features/composer/components/Composer';
 
-
 export default function Navbar() {
   const [openAddDrawer, setOpenAddDrawer] = useState(false);
   const { data: profile } = useMyProfile();

--- a/src/webapp/components/navigation/navbar/Navbar.tsx
+++ b/src/webapp/components/navigation/navbar/Navbar.tsx
@@ -20,7 +20,7 @@ import { MdOutlineEmojiNature } from 'react-icons/md';
 import { FaRegNoteSticky } from 'react-icons/fa6';
 import { TbSettings } from 'react-icons/tb';
 import { BiSearch } from 'react-icons/bi';
-import Link from 'next/link';
+
 import SembleLogo from '@/assets/semble-logo.svg';
 import ProfileMenu from '@/features/profile/components/profileMenu/ProfileMenu';
 import { Suspense, useState } from 'react';
@@ -32,6 +32,7 @@ import { track } from '@vercel/analytics';
 import NotificationNavItem from '@/features/notifications/components/notificationNavItem/NotificationNavItem';
 import Composer from '@/features/composer/components/Composer';
 
+
 export default function Navbar() {
   const [openAddDrawer, setOpenAddDrawer] = useState(false);
   const { data: profile } = useMyProfile();
@@ -39,7 +40,7 @@ export default function Navbar() {
   return (
     <AppShellNavbar p={'xs'} style={{ zIndex: 3 }}>
       <Group justify="space-between">
-        <Anchor component={Link} href={'/home'} mx={2}>
+        <Anchor href={'/home'} mx={2}>
           <Stack align="center" gap={6}>
             <Image src={SembleLogo.src} alt="Semble logo" w={20.84} h={28} />
             <Badge size="xs" style={{ cursor: 'pointer' }}>

--- a/src/webapp/components/navigation/navbar/Skeleton.Navbar.tsx
+++ b/src/webapp/components/navigation/navbar/Skeleton.Navbar.tsx
@@ -11,15 +11,16 @@ import {
   Badge,
   Skeleton,
 } from '@mantine/core';
-import Link from 'next/link';
+
 import SembleLogo from '@/assets/semble-logo.svg';
 import NavbarToggle from '../NavbarToggle';
+
 
 export default function NavbarSkeleton() {
   return (
     <AppShellNavbar p={'xs'} style={{ zIndex: 3 }}>
       <Group justify="space-between">
-        <Anchor component={Link} href={'/home'} mx={2}>
+        <Anchor href={'/home'} mx={2}>
           <Stack align="center" gap={6}>
             <Image src={SembleLogo.src} alt="Semble logo" w={20.84} h={28} />
             <Badge size="xs" style={{ cursor: 'pointer' }}>

--- a/src/webapp/components/navigation/navbar/Skeleton.Navbar.tsx
+++ b/src/webapp/components/navigation/navbar/Skeleton.Navbar.tsx
@@ -15,7 +15,6 @@ import {
 import SembleLogo from '@/assets/semble-logo.svg';
 import NavbarToggle from '../NavbarToggle';
 
-
 export default function NavbarSkeleton() {
   return (
     <AppShellNavbar p={'xs'} style={{ zIndex: 3 }}>

--- a/src/webapp/features/auth/components/loginForm/AppPasswordLoginForm.tsx
+++ b/src/webapp/features/auth/components/loginForm/AppPasswordLoginForm.tsx
@@ -24,7 +24,6 @@ import { useQuery } from '@tanstack/react-query';
 import { UseFormReturnType } from '@mantine/form';
 import { searchBlueskyUsers } from '@/features/platforms/bluesky/lib/dal';
 
-
 interface LoginFormValues {
   handle: string;
   appPassword: string;
@@ -183,12 +182,7 @@ export default function AppPasswordLoginForm(props: Props) {
             </UnstyledButton>
             <Text fw={500} fz={'sm'} c={'gray'}>
               {"Don't have an account? "}
-              <Anchor
-                href="/signup"
-                fw={500}
-                fz={'sm'}
-                c={'blue'}
-              >
+              <Anchor href="/signup" fw={500} fz={'sm'} c={'blue'}>
                 Sign up
               </Anchor>
             </Text>

--- a/src/webapp/features/auth/components/loginForm/AppPasswordLoginForm.tsx
+++ b/src/webapp/features/auth/components/loginForm/AppPasswordLoginForm.tsx
@@ -23,7 +23,7 @@ import { useDebouncedValue } from '@mantine/hooks';
 import { useQuery } from '@tanstack/react-query';
 import { UseFormReturnType } from '@mantine/form';
 import { searchBlueskyUsers } from '@/features/platforms/bluesky/lib/dal';
-import Link from 'next/link';
+
 
 interface LoginFormValues {
   handle: string;
@@ -184,7 +184,6 @@ export default function AppPasswordLoginForm(props: Props) {
             <Text fw={500} fz={'sm'} c={'gray'}>
               {"Don't have an account? "}
               <Anchor
-                component={Link}
                 href="/signup"
                 fw={500}
                 fz={'sm'}

--- a/src/webapp/features/auth/components/loginForm/OAuthLoginForm.tsx
+++ b/src/webapp/features/auth/components/loginForm/OAuthLoginForm.tsx
@@ -22,7 +22,7 @@ import { useDebouncedValue } from '@mantine/hooks';
 import { useQuery } from '@tanstack/react-query';
 import { UseFormReturnType } from '@mantine/form';
 import { searchBlueskyUsers } from '@/features/platforms/bluesky/lib/dal';
-import Link from 'next/link';
+
 
 interface LoginFormValues {
   handle: string;
@@ -170,7 +170,6 @@ export default function OAuthLoginForm(props: Props) {
             <Text fw={500} fz={'sm'} c={'gray'}>
               {"Don't have an account? "}
               <Anchor
-                component={Link}
                 href="/signup"
                 fw={500}
                 fz={'sm'}

--- a/src/webapp/features/auth/components/loginForm/OAuthLoginForm.tsx
+++ b/src/webapp/features/auth/components/loginForm/OAuthLoginForm.tsx
@@ -23,7 +23,6 @@ import { useQuery } from '@tanstack/react-query';
 import { UseFormReturnType } from '@mantine/form';
 import { searchBlueskyUsers } from '@/features/platforms/bluesky/lib/dal';
 
-
 interface LoginFormValues {
   handle: string;
   appPassword: string;
@@ -169,12 +168,7 @@ export default function OAuthLoginForm(props: Props) {
 
             <Text fw={500} fz={'sm'} c={'gray'}>
               {"Don't have an account? "}
-              <Anchor
-                href="/signup"
-                fw={500}
-                fz={'sm'}
-                c={'blue'}
-              >
+              <Anchor href="/signup" fw={500} fz={'sm'} c={'blue'}>
                 Sign up
               </Anchor>
             </Text>

--- a/src/webapp/features/cards/components/cardChip/CardChip.tsx
+++ b/src/webapp/features/cards/components/cardChip/CardChip.tsx
@@ -1,8 +1,8 @@
-import { Card, Image, Group, Text, Tooltip } from '@mantine/core';
-import Link from 'next/link';
+import { Image, Group, Text, Tooltip } from '@mantine/core';
 import { truncateText } from '@/lib/utils/text';
-import styles from './CardChip.module.css';
 import { getDomain } from '@/lib/utils/link';
+import { LinkCard } from '@/components/link/MantineLink';
+import styles from './CardChip.module.css';
 
 interface Props {
   url: string;
@@ -13,8 +13,7 @@ interface Props {
 export default function CardChip(props: Props) {
   return (
     <Tooltip label={getDomain(props.url)}>
-      <Card
-        component={Link}
+      <LinkCard
         href={`/url?id=${encodeURIComponent(props.url)}`}
         radius={'md'}
         px={7}
@@ -36,7 +35,7 @@ export default function CardChip(props: Props) {
             {truncateText(props.title || 'Card', 18)}
           </Text>
         </Group>
-      </Card>
+      </LinkCard>
     </Tooltip>
   );
 }

--- a/src/webapp/features/cards/components/cardToBeAddedPreview/CardToBeAddedPreview.tsx
+++ b/src/webapp/features/cards/components/cardToBeAddedPreview/CardToBeAddedPreview.tsx
@@ -7,8 +7,9 @@ import {
   Anchor,
   Tooltip,
 } from '@mantine/core';
-import Link from 'next/link';
+
 import { getDomain } from '@/lib/utils/link';
+
 
 interface Props {
   url: string;
@@ -40,7 +41,6 @@ export default function CardToBeAddedPreview(props: Props) {
             )}
             <Tooltip label={props.url}>
               <Anchor
-                component={Link}
                 href={props.url}
                 target="_blank"
                 c={'gray'}

--- a/src/webapp/features/cards/components/cardToBeAddedPreview/CardToBeAddedPreview.tsx
+++ b/src/webapp/features/cards/components/cardToBeAddedPreview/CardToBeAddedPreview.tsx
@@ -10,7 +10,6 @@ import {
 
 import { getDomain } from '@/lib/utils/link';
 
-
 interface Props {
   url: string;
   imageUrl?: string;

--- a/src/webapp/features/cards/components/urlCard/UrlCard.tsx
+++ b/src/webapp/features/cards/components/urlCard/UrlCard.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import type { UrlCard, Collection, User } from '@/api-client';
-import { Anchor, Avatar, Card, Group, Stack, Text } from '@mantine/core';
+import { Anchor, Card, Group, Stack, Text } from '@mantine/core';
 import UrlCardActions from '../urlCardActions/UrlCardActions';
 import { MouseEvent, Suspense } from 'react';
 import UrlCardContent from '../urlCardContent/UrlCardContent';
@@ -10,11 +10,11 @@ import { isCollectionPage, isProfilePage } from '@/lib/utils/link';
 import styles from './UrlCard.module.css';
 import { useUserSettings } from '@/features/settings/lib/queries/useUserSettings';
 import UrlCardDebugView from '../UrlCardDebugView/UrlCardDebugView';
-import Link from 'next/link';
 import { CardSaveAnalyticsContext } from '@/features/analytics/types';
 import posthog from 'posthog-js';
 import { shouldCaptureAnalytics } from '@/features/analytics/utils';
 import UrlCardContentSkeleton from '../urlCardContent/Skeleton.UrlCardContent';
+import { LinkAvatar } from '@/components/link/MantineLink';
 
 interface Props {
   id: string;
@@ -128,8 +128,7 @@ export default function UrlCard(props: Props) {
                 Added by{' '}
               </Text>
               <Group gap={'5'}>
-                <Avatar
-                  component={Link}
+                <LinkAvatar
                   href={`/profile/${props.cardAuthor?.handle}`}
                   src={props.cardAuthor?.avatarUrl?.replace(
                     'avatar',
@@ -140,7 +139,6 @@ export default function UrlCard(props: Props) {
                   radius={'sm'}
                 />
                 <Anchor
-                  component={Link}
                   href={`/profile/${props.cardAuthor.handle}`}
                   fz={'xs'}
                   fw={600}

--- a/src/webapp/features/cards/components/urlCardContent/LinkCardContent.tsx
+++ b/src/webapp/features/cards/components/urlCardContent/LinkCardContent.tsx
@@ -17,7 +17,6 @@ import { useState } from 'react';
 import { isMarginUri, getMarginUrl } from '@/lib/utils/margin';
 import MarginLogo from '@/components/MarginLogo';
 
-
 interface Props {
   cardContent: UrlCard['cardContent'];
   uri?: string;

--- a/src/webapp/features/cards/components/urlCardContent/LinkCardContent.tsx
+++ b/src/webapp/features/cards/components/urlCardContent/LinkCardContent.tsx
@@ -12,10 +12,11 @@ import {
   Image,
 } from '@mantine/core';
 import { UrlCard } from '@semble/types';
-import Link from 'next/link';
+
 import { useState } from 'react';
 import { isMarginUri, getMarginUrl } from '@/lib/utils/margin';
 import MarginLogo from '@/components/MarginLogo';
+
 
 interface Props {
   cardContent: UrlCard['cardContent'];
@@ -36,7 +37,6 @@ export default function LinkCardContent(props: Props) {
           <Tooltip label={props.cardContent.url}>
             <Anchor
               onClick={(e) => e.stopPropagation()}
-              component={Link}
               href={props.cardContent.url}
               target="_blank"
               c={'gray'}

--- a/src/webapp/features/cards/components/urlCardContent/SembleCollectionCardContent.tsx
+++ b/src/webapp/features/cards/components/urlCardContent/SembleCollectionCardContent.tsx
@@ -3,11 +3,10 @@
 import CollectionCardPreview from '@/features/collections/components/collectionCardPreview/CollectionCardPreview';
 import CollectionCardPreviewSkeleton from '@/features/collections/components/collectionCardPreview/Skeleton.CollectionCardPreview';
 import useCollection from '@/features/collections/lib/queries/useCollection';
-import { Avatar, Group, Stack, Text, ThemeIcon, Tooltip } from '@mantine/core';
+import { Group, Stack, Text } from '@mantine/core';
 import { CollectionAccessType } from '@semble/types';
-import Link from 'next/link';
 import { Suspense } from 'react';
-import { FaSeedling } from 'react-icons/fa6';
+import { LinkAvatar } from '@/components/link/MantineLink';
 
 interface Props {
   rkey: string;
@@ -41,8 +40,7 @@ export default function SembleCollectionCardContent(props: Props) {
             )}
           </Group>
 
-          <Avatar
-            component={Link}
+          <LinkAvatar
             href={`/profile/${collection.author.handle}`}
             src={collection.author.avatarUrl?.replace(
               'avatar',

--- a/src/webapp/features/collections/components/collectionCard/CollectionCard.tsx
+++ b/src/webapp/features/collections/components/collectionCard/CollectionCard.tsx
@@ -3,18 +3,18 @@
 import { CollectionAccessType, type Collection } from '@/api-client';
 import { getRecordKey } from '@/lib/utils/atproto';
 import { getRelativeTime } from '@/lib/utils/time';
-import { Avatar, Card, Group, Stack, Text } from '@mantine/core';
-import styles from './CollectionCard.module.css';
+import { Card, Group, Stack, Text } from '@mantine/core';
 import CollectionCardPreview from '../collectionCardPreview/CollectionCardPreview';
 import { Suspense } from 'react';
 import CollectionCardPreviewSkeleton from '../collectionCardPreview/Skeleton.CollectionCardPreview';
-import Link from 'next/link';
 import { useUserSettings } from '@/features/settings/lib/queries/useUserSettings';
 import CollectionCardDebugView from '../collectionCardDebugView/CollectionCardDebugView';
 import { useRouter } from 'next/navigation';
 import { MouseEvent } from 'react';
 import { isMarginUri, getMarginUrl } from '@/lib/utils/margin';
 import MarginLogo from '@/components/MarginLogo';
+import { LinkAvatar } from '@/components/link/MantineLink';
+import styles from './CollectionCard.module.css';
 
 interface Props {
   size?: 'large' | 'compact' | 'list' | 'basic';
@@ -84,8 +84,7 @@ export default function CollectionCard(props: Props) {
               </Group>
 
               {props.showAuthor && (
-                <Avatar
-                  component={Link}
+                <LinkAvatar
                   href={`/profile/${collection.author.handle}`}
                   src={collection.author.avatarUrl?.replace(
                     'avatar',

--- a/src/webapp/features/collections/components/collectionContributorsSummary/CollectionContributorsSummary.tsx
+++ b/src/webapp/features/collections/components/collectionContributorsSummary/CollectionContributorsSummary.tsx
@@ -1,9 +1,9 @@
 'use client';
 
-import { Anchor, Avatar, AvatarGroup, Text } from '@mantine/core';
-import Link from 'next/link';
+import { Anchor, AvatarGroup, Text } from '@mantine/core';
 import useCollectionContributors from '../../lib/queries/useCollectionContributors';
 import { Fragment } from 'react';
+import { LinkAvatar } from '@/components/link/MantineLink';
 
 interface Props {
   collectionId: string;
@@ -30,9 +30,8 @@ export default function CollectionContributorsShortcut({
       </Text>
       <AvatarGroup>
         {data.pages[0].users.slice(0, 3).map((u) => (
-          <Avatar
+          <LinkAvatar
             key={u.id}
-            component={Link}
             href={`/profile/${handle}/collections/${rkey}/contributors`}
             src={u.avatarUrl?.replace('avatar', 'avatar_thumbnail')}
             alt={`${u.handle}'s avatar`}
@@ -42,7 +41,6 @@ export default function CollectionContributorsShortcut({
         ))}
       </AvatarGroup>
       <Anchor
-        component={Link}
         href={`/profile/${handle}/collections/${rkey}/contributors`}
         fz="sm"
         fw={600}

--- a/src/webapp/features/collections/components/collectionHeader/CollectionHeader.tsx
+++ b/src/webapp/features/collections/components/collectionHeader/CollectionHeader.tsx
@@ -7,14 +7,12 @@ import {
   Stack,
   Text,
   Title,
-  Avatar,
   Tooltip,
   Badge,
   Box,
   Divider,
 } from '@mantine/core';
 import useCollection from '../../lib/queries/useCollection';
-import Link from 'next/link';
 import { Fragment, Suspense } from 'react';
 import CollectionContributorsSummary from '../collectionContributorsSummary/CollectionContributorsSummary';
 import CollectionActions from '../collectionActions/CollectionActions';
@@ -23,6 +21,7 @@ import { FaSeedling } from 'react-icons/fa6';
 import { isMarginUri, getMarginUrl } from '@/lib/utils/margin';
 import MarginLogo from '@/components/MarginLogo';
 import { getRelativeTime } from '@/lib/utils/time';
+import { LinkAvatar } from '@/components/link/MantineLink';
 
 interface Props {
   rkey: string;
@@ -113,10 +112,9 @@ export default function CollectionHeader(props: Props) {
             <Group justify="space-between" gap={'lg'}>
               <Stack gap={'xs'}>
                 <Group gap={5}>
-                  <Avatar
+                  <LinkAvatar
                     size={'xs'}
                     radius={'sm'}
-                    component={Link}
                     href={`/profile/${collection.author.handle}`}
                     src={collection.author.avatarUrl?.replace(
                       'avatar',
@@ -125,7 +123,6 @@ export default function CollectionHeader(props: Props) {
                     alt={`${collection.author.name}'s avatar`}
                   />
                   <Anchor
-                    component={Link}
                     href={`/profile/${collection.author.handle}`}
                     fw={600}
                     fz={'sm'}
@@ -143,7 +140,6 @@ export default function CollectionHeader(props: Props) {
                 </Group>
                 <Group gap={'xs'}>
                   <Anchor
-                    component={Link}
                     href={`/profile/${collection.author.handle}/collections/${props.rkey}`}
                     underline="never"
                   >
@@ -161,7 +157,6 @@ export default function CollectionHeader(props: Props) {
 
                   <>
                     <Anchor
-                      component={Link}
                       href={`/profile/${collection.author.handle}/collections/${props.rkey}/followers`}
                       underline="never"
                     >

--- a/src/webapp/features/collections/components/collectionNavItem/CollectionNavItem.tsx
+++ b/src/webapp/features/collections/components/collectionNavItem/CollectionNavItem.tsx
@@ -1,12 +1,12 @@
 import { useNavbarContext } from '@/providers/navbar';
-import { Badge, NavLink } from '@mantine/core';
-import Link from 'next/link';
+import { Badge } from '@mantine/core';
 import { usePathname } from 'next/navigation';
 import styles from './CollectionNavItem.module.css';
 import { isMarginUri } from '@/lib/utils/margin';
 import MarginLogo from '@/components/MarginLogo';
 import { CollectionAccessType } from '@semble/types';
 import { abbreviateNumber } from '@/lib/utils/text';
+import { LinkNavLink } from '@/components/link/MantineLink';
 
 interface Props {
   name: string;
@@ -24,8 +24,7 @@ export default function CollectionNavItem(props: Props) {
   const isOpenCollection = props.accessType === CollectionAccessType.OPEN;
 
   return (
-    <NavLink
-      component={Link}
+    <LinkNavLink
       href={props.url}
       label={props.name}
       active={isActive}

--- a/src/webapp/features/collections/components/collectionStats/CollectionStats.tsx
+++ b/src/webapp/features/collections/components/collectionStats/CollectionStats.tsx
@@ -1,9 +1,9 @@
 'use client';
 
-import { Badge, Skeleton } from '@mantine/core';
+import { Skeleton } from '@mantine/core';
 import { Suspense } from 'react';
 import useCollectionFollowersCount from '@/features/follows/lib/queries/useCollectionFollowersCount';
-import Link from 'next/link';
+import { LinkBadge } from '@/components/link/MantineLink';
 
 interface Props {
   collectionId: string;
@@ -17,8 +17,7 @@ function CollectionStatsContent({ collectionId, handle, rkey }: Props) {
   });
 
   return (
-    <Badge
-      component={Link}
+    <LinkBadge
       href={`/profile/${handle}/collections/${rkey}/followers`}
       variant="light"
       color="gray"
@@ -26,7 +25,7 @@ function CollectionStatsContent({ collectionId, handle, rkey }: Props) {
       style={{ cursor: 'pointer' }}
     >
       {followersCount.count} Follower{followersCount.count !== 1 ? 's' : ''}
-    </Badge>
+    </LinkBadge>
   );
 }
 

--- a/src/webapp/features/collections/components/collectionsNavList/CollectionsNavList.tsx
+++ b/src/webapp/features/collections/components/collectionsNavList/CollectionsNavList.tsx
@@ -1,7 +1,6 @@
 'use client';
 
-import Link from 'next/link';
-import { Button, Group, NavLink, Stack, Text } from '@mantine/core';
+import { Group, NavLink, Stack, Text } from '@mantine/core';
 import CollectionNavItem from '../collectionNavItem/CollectionNavItem';
 import useMyCollections from '../../lib/queries/useMyCollections';
 import CollectionsNavListError from './Error.CollectionsNavList';
@@ -11,6 +10,7 @@ import { getRecordKey } from '@/lib/utils/atproto';
 import { useNavbarContext } from '@/providers/navbar';
 import useFollowingCollections from '@/features/follows/lib/queries/useFollowingCollections';
 import { useUserSettings } from '@/features/settings/lib/queries/useUserSettings';
+import { LinkButton, LinkNavLink } from '@/components/link/MantineLink';
 
 export default function CollectionsNavList() {
   const { toggleMobile } = useNavbarContext();
@@ -38,8 +38,7 @@ export default function CollectionsNavList() {
         </Text>
 
         <Group gap={'xs'}>
-          <Button
-            component={Link}
+          <LinkButton
             href={`/profile/${profile.handle}/collections`}
             variant="light"
             radius={'xl'}
@@ -48,7 +47,7 @@ export default function CollectionsNavList() {
             onClick={toggleMobile}
           >
             View all
-          </Button>
+          </LinkButton>
           <CreateCollectionShortcut />
         </Group>
       </Group>
@@ -71,8 +70,7 @@ export default function CollectionsNavList() {
                 uri={collection.uri}
               />
             ))}
-            <NavLink
-              component={Link}
+            <LinkNavLink
               href={`/profile/${profile.handle}/collections`}
               label="View all"
               variant="subtle"
@@ -99,8 +97,7 @@ export default function CollectionsNavList() {
                 uri={collection.uri}
               />
             ))}
-            <NavLink
-              component={Link}
+            <LinkNavLink
               href={`/profile/${profile.handle}/network/collections-following`}
               label="View all"
               variant="subtle"

--- a/src/webapp/features/collections/containers/collectionContainerContent/CollectionContainerContent.tsx
+++ b/src/webapp/features/collections/containers/collectionContainerContent/CollectionContainerContent.tsx
@@ -19,10 +19,11 @@ import {
 import InfiniteScroll from '@/components/contentDisplay/infiniteScroll/InfiniteScroll';
 import UrlCard from '@/features/cards/components/urlCard/UrlCard';
 import AddCardDrawer from '@/features/cards/components/addCardDrawer/AddCardDrawer';
-import Link from 'next/link';
+
 import { FiPlus } from 'react-icons/fi';
 import { useSearchParams, usePathname } from 'next/navigation';
 import { CardSaveSource } from '@/features/analytics/types';
+
 
 interface Props {
   rkey: string;
@@ -141,7 +142,7 @@ export default function CollectionContainerContent(props: Props) {
               </Button>
               <Text ta={'center'} fw={500} c={'gray'}>
                 Need inspiration?{' '}
-                <Anchor component={Link} href={'/explore'} fw={500} c={'grape'}>
+                <Anchor href={'/explore'} fw={500} c={'grape'}>
                   Explore cards from the community
                 </Anchor>
               </Text>

--- a/src/webapp/features/collections/containers/collectionContainerContent/CollectionContainerContent.tsx
+++ b/src/webapp/features/collections/containers/collectionContainerContent/CollectionContainerContent.tsx
@@ -24,7 +24,6 @@ import { FiPlus } from 'react-icons/fi';
 import { useSearchParams, usePathname } from 'next/navigation';
 import { CardSaveSource } from '@/features/analytics/types';
 
-
 interface Props {
   rkey: string;
   handle: string;

--- a/src/webapp/features/collections/containers/collectionEmbedContainer/CollectionEmbedContainer.tsx
+++ b/src/webapp/features/collections/containers/collectionEmbedContainer/CollectionEmbedContainer.tsx
@@ -7,16 +7,13 @@ import {
   Stack,
   Text,
   Title,
-  Avatar,
   Grid,
   Image,
-  Button,
   Card,
   Tooltip,
   Badge,
 } from '@mantine/core';
 import SembleLogo from '@/assets/semble-logo.svg';
-import Link from 'next/link';
 import { RiArrowRightUpLine } from 'react-icons/ri';
 import UrlCardContent from '@/features/cards/components/urlCardContent/UrlCardContent';
 import { isCollectionPage, isProfilePage } from '@/lib/utils/link';
@@ -26,6 +23,7 @@ import InfiniteScroll from '@/components/contentDisplay/infiniteScroll/InfiniteS
 import { useRouter } from 'next/navigation';
 import { CollectionAccessType } from '@semble/types';
 import { FaSeedling } from 'react-icons/fa6';
+import { LinkAvatar, LinkButton } from '@/components/link/MantineLink';
 
 interface Props {
   rkey: string;
@@ -49,7 +47,7 @@ export default function CollectionEmbedContainer(props: Props) {
       <Stack justify="flex-start">
         <Group justify="space-between" align="start">
           <Stack gap={'xs'} align="flex-start">
-            <Anchor component={Link} href={appUrl} target="_blank">
+            <Anchor href={appUrl} target="_blank">
               <Image src={SembleLogo.src} alt="Semble logo" w={'auto'} h={30} />
             </Anchor>
             <Stack gap={0}>
@@ -89,10 +87,9 @@ export default function CollectionEmbedContainer(props: Props) {
           </Stack>
 
           <Group gap={5} wrap="nowrap">
-            <Avatar
+            <LinkAvatar
               size={'xs'}
               radius={'sm'}
-              component={Link}
               href={`/profile/${firstPage.author.handle}`}
               target="_blank"
               src={firstPage.author.avatarUrl?.replace(
@@ -102,7 +99,6 @@ export default function CollectionEmbedContainer(props: Props) {
               alt={`${firstPage.author.name}'s avatar`}
             />
             <Anchor
-              component={Link}
               href={`/profile/${firstPage.author.handle}`}
               target="_blank"
               fw={600}
@@ -179,8 +175,7 @@ export default function CollectionEmbedContainer(props: Props) {
         </Fragment>
 
         <Stack align="center" mt={'md'}>
-          <Button
-            component={Link}
+          <LinkButton
             href={`${appUrl}/profile/${props.handle}/collections/${props.rkey}`}
             target="_blank"
             variant="light"
@@ -188,7 +183,7 @@ export default function CollectionEmbedContainer(props: Props) {
             rightSection={<RiArrowRightUpLine />}
           >
             View on Semble
-          </Button>
+          </LinkButton>
         </Stack>
       </Stack>
     </Container>

--- a/src/webapp/features/collections/containers/collectionGalleryEmbedContainer/CollectionGalleryEmbedContainer.tsx
+++ b/src/webapp/features/collections/containers/collectionGalleryEmbedContainer/CollectionGalleryEmbedContainer.tsx
@@ -6,7 +6,6 @@ import {
   Group,
   Stack,
   Text,
-  Avatar,
   Card,
   ActionIcon,
   Image,
@@ -16,7 +15,6 @@ import {
   Badge,
 } from '@mantine/core';
 import SembleLogo from '@/assets/semble-logo.svg';
-import Link from 'next/link';
 import UrlCardContent from '@/features/cards/components/urlCardContent/UrlCardContent';
 import { isCollectionPage, isProfilePage } from '@/lib/utils/link';
 import useCollection from '../../lib/queries/useCollection';
@@ -28,6 +26,7 @@ import {
   useRpcSession,
 } from '@/lib/embed/rpcSessionProvider';
 import { FaSeedling } from 'react-icons/fa6';
+import { LinkActionIcon, LinkAvatar } from '@/components/link/MantineLink';
 
 interface Props {
   rkey: string;
@@ -138,10 +137,9 @@ function CollectionGalleryContent(props: Props) {
             </Stack>
 
             <Group gap={5} wrap="nowrap">
-              <Avatar
+              <LinkAvatar
                 size={'xs'}
                 radius={'sm'}
-                component={Link}
                 href={`/profile/${firstPage.author.handle}`}
                 target="_blank"
                 src={firstPage.author.avatarUrl?.replace(
@@ -151,7 +149,6 @@ function CollectionGalleryContent(props: Props) {
                 alt={`${firstPage.author.name}'s avatar`}
               />
               <Anchor
-                component={Link}
                 href={`/profile/${firstPage.author.handle}`}
                 target="_blank"
                 fw={600}
@@ -274,16 +271,15 @@ function CollectionGalleryContent(props: Props) {
                   View Collection
                 </Button>
 
-                <ActionIcon
+                <LinkActionIcon
                   size="compact-xs"
                   variant="transparent"
                   radius={'xs'}
-                  component={Link}
                   href={`${appUrl}/profile/${props.handle}/collections/${props.rkey}`}
                   target="_blank"
                 >
                   <Image src={SembleLogo.src} h={20} />
-                </ActionIcon>
+                </LinkActionIcon>
               </>
             )}
           </Group>

--- a/src/webapp/features/connections/components/addConnectionDrawer/SourceCardPreview.tsx
+++ b/src/webapp/features/connections/components/addConnectionDrawer/SourceCardPreview.tsx
@@ -14,7 +14,7 @@ import {
 import { useQuery } from '@tanstack/react-query';
 import { createSembleClient } from '@/services/client.apiClient';
 import { getDomain } from '@/lib/utils/link';
-import Link from 'next/link';
+
 
 function SourceCardPreviewSkeleton() {
   return (
@@ -68,7 +68,6 @@ export default function SourceCardPreview(props: Props) {
           </Text>
           <Tooltip label={props.sourceUrl}>
             <Anchor
-              component={Link}
               href={props.sourceUrl}
               target="_blank"
               c={'gray'}

--- a/src/webapp/features/connections/components/addConnectionDrawer/SourceCardPreview.tsx
+++ b/src/webapp/features/connections/components/addConnectionDrawer/SourceCardPreview.tsx
@@ -15,7 +15,6 @@ import { useQuery } from '@tanstack/react-query';
 import { createSembleClient } from '@/services/client.apiClient';
 import { getDomain } from '@/lib/utils/link';
 
-
 function SourceCardPreviewSkeleton() {
   return (
     <Card withBorder component="article" p={'xs'} radius={'lg'}>

--- a/src/webapp/features/connections/components/connectionItem/ConnectionStatus.tsx
+++ b/src/webapp/features/connections/components/connectionItem/ConnectionStatus.tsx
@@ -1,5 +1,4 @@
 import {
-  Avatar,
   Card,
   Group,
   Spoiler,
@@ -11,8 +10,6 @@ import {
   Box,
 } from '@mantine/core';
 import { ConnectionWithSourceAndTarget, UrlView } from '@semble/types';
-import Link from 'next/link';
-import styles from './ConnectionStatus.module.css';
 import { getRelativeTime } from '@/lib/utils/time';
 import { sanitizeText } from '@/lib/utils/text';
 import { useAuth } from '@/hooks/useAuth';
@@ -23,6 +20,8 @@ import DeleteConnectionModal from '../deleteConnectionModal/DeleteConnectionModa
 import CardChip from '@/features/cards/components/cardChip/CardChip';
 import { BsTrash2Fill } from 'react-icons/bs';
 import { CONNECTION_TYPES } from '../../const/connectionTypes';
+import { LinkAvatar, LinkText } from '@/components/link/MantineLink';
+import styles from './ConnectionStatus.module.css';
 
 interface Props {
   connection: ConnectionWithSourceAndTarget['connection'];
@@ -50,14 +49,9 @@ export default function ConnectionStatus(props: Props) {
     return (
       <Text component="div" fw={500}>
         <Group gap={5} wrap="wrap" align="center">
-          <Text
-            component={Link}
-            href={`/profile/${curator.handle}`}
-            fw={600}
-            c={'bright'}
-          >
+          <LinkText href={`/profile/${curator.handle}`} fw={600} c={'bright'}>
             {sanitizeText(curator.name)}
-          </Text>
+          </LinkText>
           <Text>connected</Text>
           <CardChip
             url={props.source.url}
@@ -81,8 +75,7 @@ export default function ConnectionStatus(props: Props) {
         <Stack gap={'xs'} p={'xs'}>
           {/* Header row: avatar + connection text */}
           <Group gap={'xs'} wrap="nowrap" align="center">
-            <Avatar
-              component={Link}
+            <LinkAvatar
               href={`/profile/${props.connection.curator.handle}`}
               src={props.connection.curator.avatarUrl?.replace(
                 'avatar',

--- a/src/webapp/features/connections/components/editConnectionForm/EditConnectionForm.tsx
+++ b/src/webapp/features/connections/components/editConnectionForm/EditConnectionForm.tsx
@@ -33,7 +33,6 @@ import { BsCheck, BsExclamation } from 'react-icons/bs';
 import { ConnectionWithSourceAndTarget } from '@semble/types';
 import { BiSolidChevronDown } from 'react-icons/bi';
 
-
 interface Props {
   onClose: () => void;
   sourceUrl: string;

--- a/src/webapp/features/connections/components/editConnectionForm/EditConnectionForm.tsx
+++ b/src/webapp/features/connections/components/editConnectionForm/EditConnectionForm.tsx
@@ -28,10 +28,11 @@ import { createSembleClient } from '@/services/client.apiClient';
 import { getDomain } from '@/lib/utils/link';
 import { LuChevronsUpDown, LuArrowUpDown } from 'react-icons/lu';
 import { CONNECTION_TYPES } from '../../const/connectionTypes';
-import Link from 'next/link';
+
 import { BsCheck, BsExclamation } from 'react-icons/bs';
 import { ConnectionWithSourceAndTarget } from '@semble/types';
 import { BiSolidChevronDown } from 'react-icons/bi';
+
 
 interface Props {
   onClose: () => void;
@@ -206,7 +207,6 @@ export default function EditConnectionForm(props: Props) {
                   <Skeleton visible={isLoadingSourceMetadata} mt={4}>
                     <Tooltip label={form.values.sourceUrl}>
                       <Anchor
-                        component={Link}
                         href={form.values.sourceUrl}
                         target="_blank"
                         c={'gray'}
@@ -366,7 +366,6 @@ export default function EditConnectionForm(props: Props) {
                 <Skeleton visible={isLoadingTargetMetadata} mt={4}>
                   <Tooltip label={form.values.targetUrl}>
                     <Anchor
-                      component={Link}
                       href={form.values.targetUrl}
                       target="_blank"
                       c={'gray'}

--- a/src/webapp/features/connections/components/profileConnectionItem/ProfileConnectionItem.tsx
+++ b/src/webapp/features/connections/components/profileConnectionItem/ProfileConnectionItem.tsx
@@ -1,12 +1,11 @@
 import type { ConnectionWithSourceAndTarget, User } from '@semble/types';
-import Link from 'next/link';
+
 import {
   Stack,
   Card,
   Group,
   Text,
   Box,
-  Avatar,
   ActionIcon,
   Menu,
   Spoiler,
@@ -19,6 +18,7 @@ import DeleteConnectionModal from '../deleteConnectionModal/DeleteConnectionModa
 import ConnectionCard from '../connectionCard/ConnectionCard';
 import styles from './ProfileConnectionItem.module.css';
 import { BsThreeDots, BsTrash2Fill } from 'react-icons/bs';
+import { LinkAvatar, LinkText } from '@/components/link/MantineLink';
 
 interface Props {
   connection: ConnectionWithSourceAndTarget;
@@ -46,8 +46,7 @@ export default function ProfileConnectionItem(props: Props) {
             <Stack gap={'xs'}>
               <Group justify="space-between" align="center" wrap="nowrap">
                 <Group gap={'xs'} wrap="nowrap" miw={0}>
-                  <Avatar
-                    component={Link}
+                  <LinkAvatar
                     href={`/profile/${props.curator.handle}`}
                     src={props.curator.avatarUrl?.replace(
                       'avatar',
@@ -57,15 +56,14 @@ export default function ProfileConnectionItem(props: Props) {
                     size={'sm'}
                   />
                   <Group gap={5} wrap="nowrap" miw={0}>
-                    <Text
+                    <LinkText
                       c={'bright'}
                       fw={600}
-                      component={Link}
                       href={`/profile/${props.curator.handle}`}
                       truncate
                     >
                       {props.curator.name}
-                    </Text>
+                    </LinkText>
                     {props.activityStatusText && (
                       <Text fw={500} span>
                         {' '}

--- a/src/webapp/features/feeds/components/feedActivityStatus/FeedActivityStatus.tsx
+++ b/src/webapp/features/feeds/components/feedActivityStatus/FeedActivityStatus.tsx
@@ -1,11 +1,9 @@
 import {
   Anchor,
-  Avatar,
   Card,
   Group,
   Menu,
   MenuDropdown,
-  MenuItem,
   MenuTarget,
   ScrollArea,
   Spoiler,
@@ -15,11 +13,15 @@ import {
 import { ActivityType, Collection, CollectionAccessType } from '@/api-client';
 import { User } from '@semble/types';
 import { Fragment, ReactNode } from 'react';
-import Link from 'next/link';
 import styles from './FeedActivityStatus.module.css';
 import { getRelativeTime } from '@/lib/utils/time';
 import { getRecordKey } from '@/lib/utils/atproto';
 import { sanitizeText } from '@/lib/utils/text';
+import {
+  LinkAvatar,
+  LinkMenuItem,
+  LinkText,
+} from '@/components/link/MantineLink';
 
 interface Props {
   user: User;
@@ -39,14 +41,13 @@ export default function FeedActivityStatus(props: Props) {
     if (props.activityType === ActivityType.CONNECTION_CREATED) {
       return (
         <Text fw={500}>
-          <Text
-            component={Link}
+          <LinkText
             href={`/profile/${props.user.handle}`}
             fw={600}
             c={'bright'}
           >
             {sanitizeText(props.user.name)}
-          </Text>{' '}
+          </LinkText>{' '}
           <Text span>made a connection</Text>
           <Text fz={'sm'} fw={600} c={'gray'} span display={'block'}>
             {relativeCreatedDate}
@@ -65,14 +66,9 @@ export default function FeedActivityStatus(props: Props) {
 
     return (
       <Text fw={500}>
-        <Text
-          component={Link}
-          href={`/profile/${props.user.handle}`}
-          fw={600}
-          c={'bright'}
-        >
+        <LinkText href={`/profile/${props.user.handle}`} fw={600} c={'bright'}>
           {sanitizeText(props.user.name)}
-        </Text>{' '}
+        </LinkText>{' '}
         {collections.length === 0 ? (
           <Text span>added to library</Text>
         ) : (
@@ -82,7 +78,6 @@ export default function FeedActivityStatus(props: Props) {
               (collection: Collection, index: number) => (
                 <span key={collection.id}>
                   <Anchor
-                    component={Link}
                     href={`/profile/${collection.author.handle}/collections/${getRecordKey(collection.uri!)}`}
                     c={
                       collection.accessType === CollectionAccessType.OPEN
@@ -114,9 +109,8 @@ export default function FeedActivityStatus(props: Props) {
                 <MenuDropdown maw={380}>
                   <ScrollArea.Autosize mah={150} type="auto">
                     {remainingCollections.map((c) => (
-                      <MenuItem
+                      <LinkMenuItem
                         key={c.id}
-                        component={Link}
                         href={`/profile/${c.author.handle}/collections/${getRecordKey(c.uri!)}`}
                         target="_blank"
                         c={
@@ -127,7 +121,7 @@ export default function FeedActivityStatus(props: Props) {
                         fw={600}
                       >
                         {c.name}
-                      </MenuItem>
+                      </LinkMenuItem>
                     ))}
                   </ScrollArea.Autosize>
                 </MenuDropdown>
@@ -147,8 +141,7 @@ export default function FeedActivityStatus(props: Props) {
       <Stack gap={'xs'} p={'xs'}>
         <Group gap={'xs'} wrap="nowrap" align="center" justify="space-between">
           <Group gap={'xs'} wrap="nowrap" align="center">
-            <Avatar
-              component={Link}
+            <LinkAvatar
               href={`/profile/${props.user.handle}`}
               src={props.user.avatarUrl?.replace('avatar', 'avatar_thumbnail')}
               alt={`${props.user.name}'s avatar`}

--- a/src/webapp/features/feeds/components/feedControls/FeedControls.tsx
+++ b/src/webapp/features/feeds/components/feedControls/FeedControls.tsx
@@ -8,7 +8,6 @@ import {
   Image,
   Popover,
 } from '@mantine/core';
-import Link from 'next/link';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { ActivitySource, UrlType, ActivityType } from '@semble/types';
 import { useOptimistic, useState, useTransition } from 'react';
@@ -20,6 +19,7 @@ import { getUrlTypeIcon } from '@/lib/utils/icon';
 import { upperFirst } from '@mantine/hooks';
 import { MdFilterList } from 'react-icons/md';
 import { BiLink } from 'react-icons/bi';
+import { LinkButton } from '@/components/link/MantineLink';
 
 const sourceOptions = [
   { value: null, label: 'All', icon: null },
@@ -353,23 +353,21 @@ export default function FeedControls() {
         </Menu>
 
         <Group gap={'xs'}>
-          <Button
-            component={Link}
+          <LinkButton
             href={'/explore/open-collections'}
             color="green"
             variant="light"
           >
             <FaSeedling />
-          </Button>
-          <Button
-            component={Link}
+          </LinkButton>
+          <LinkButton
             href={'/explore/atmosphereConf-collections'}
             color="#4098FF"
             variant="light"
             fz={'md'}
           >
             🪿
-          </Button>
+          </LinkButton>
         </Group>
       </Group>
     </ScrollAreaAutosize>

--- a/src/webapp/features/home/components/atmosphereConfBanner/AtmosphereConfBanner.tsx
+++ b/src/webapp/features/home/components/atmosphereConfBanner/AtmosphereConfBanner.tsx
@@ -1,7 +1,7 @@
-import { Button, Card, Group, Text, Stack, Image } from '@mantine/core';
+import { Card, Group, Text, Stack, Image } from '@mantine/core';
 import AtmosphereConfBannerImage from '@/assets/atmosphereConf-banner.webp';
 import Goosetopher from '@/assets/goosetopher.webp';
-import Link from 'next/link';
+import { LinkButton } from '@/components/link/MantineLink';
 
 export default function AtmosphereConfBanner() {
   return (
@@ -34,15 +34,14 @@ export default function AtmosphereConfBanner() {
               collection's name or description
             </Text>
           </Stack>
-          <Button
-            component={Link}
+          <LinkButton
             href="/explore/atmosphereConf-collections"
             size="md"
             variant="white"
             color={'blue.8'}
           >
             View Collections
-          </Button>
+          </LinkButton>
         </Stack>
         <Image
           src={Goosetopher.src}

--- a/src/webapp/features/home/components/discoverOnSemble/DiscoverOnSemble.tsx
+++ b/src/webapp/features/home/components/discoverOnSemble/DiscoverOnSemble.tsx
@@ -5,19 +5,11 @@ import useMyProfile from '@/features/profile/lib/queries/useMyProfile';
 import SimilarUrlCard from '@/features/semble/components/similarUrlCard/SimilarUrlCard';
 import useSembleSimilarCards from '@/features/semble/lib/queries/useSembleSimilarCards';
 import { useNavbarContext } from '@/providers/navbar';
-import {
-  Button,
-  Divider,
-  Grid,
-  Group,
-  Stack,
-  Text,
-  Title,
-} from '@mantine/core';
-import Link from 'next/link';
+import { Divider, Grid, Group, Stack, Text, Title } from '@mantine/core';
 import { Fragment } from 'react';
 import { MdOutlineEmojiNature } from 'react-icons/md';
 import { useUserSettings } from '@/features/settings/lib/queries/useUserSettings';
+import { LinkButton } from '@/components/link/MantineLink';
 
 export default function DiscoverOnSemble() {
   const { desktopOpened } = useNavbarContext();
@@ -45,9 +37,9 @@ export default function DiscoverOnSemble() {
             }`}
           </Text>
         </Stack>
-        <Button variant="light" component={Link} color="blue" href={'/explore'}>
+        <LinkButton variant="light" color="blue" href={'/explore'}>
           Explore
-        </Button>
+        </LinkButton>
       </Group>
 
       {cards.length > 0 ? (

--- a/src/webapp/features/home/components/discoverOnSemble/Skeleton.DiscoverOnSemble.tsx
+++ b/src/webapp/features/home/components/discoverOnSemble/Skeleton.DiscoverOnSemble.tsx
@@ -1,15 +1,7 @@
-import {
-  Button,
-  Grid,
-  GridCol,
-  Group,
-  Stack,
-  Title,
-  Text,
-} from '@mantine/core';
+import { Grid, GridCol, Group, Stack, Title, Text } from '@mantine/core';
 import UrlCardSkeleton from '@/features/cards/components/urlCard/Skeleton.UrlCard';
-import Link from 'next/link';
 import { MdOutlineEmojiNature } from 'react-icons/md';
+import { LinkButton } from '@/components/link/MantineLink';
 
 export default function DiscoverOnSembleSkeleton() {
   return (
@@ -24,9 +16,9 @@ export default function DiscoverOnSembleSkeleton() {
             Recommendations based on your activity
           </Text>
         </Stack>
-        <Button variant="light" component={Link} color="blue" href={'/explore'}>
+        <LinkButton variant="light" color="blue" href={'/explore'}>
           Explore
-        </Button>
+        </LinkButton>
       </Group>
 
       <Grid gutter="xs">

--- a/src/webapp/features/home/components/recentCards/RecentCards.tsx
+++ b/src/webapp/features/home/components/recentCards/RecentCards.tsx
@@ -15,11 +15,11 @@ import {
   Text,
   Title,
 } from '@mantine/core';
-import Link from 'next/link';
 import { Fragment, useState } from 'react';
 import { FaRegNoteSticky } from 'react-icons/fa6';
 import { useUserSettings } from '@/features/settings/lib/queries/useUserSettings';
 import { FiPlus } from 'react-icons/fi';
+import { LinkButton } from '@/components/link/MantineLink';
 
 export default function RecentCards() {
   const { desktopOpened } = useNavbarContext();
@@ -36,14 +36,13 @@ export default function RecentCards() {
           <FaRegNoteSticky size={22} />
           <Title order={2}>Cards</Title>
         </Group>
-        <Button
+        <LinkButton
           variant="light"
-          component={Link}
           color="blue"
           href={`/profile/${profile.handle}/cards`}
         >
           View all
-        </Button>
+        </LinkButton>
       </Group>
 
       {cards.length > 0 ? (
@@ -99,7 +98,7 @@ export default function RecentCards() {
 
             <Text ta={'center'} fw={500} c={'gray'}>
               Need inspiration?{' '}
-              <Anchor component={Link} href={'/explore'} fw={500} c={'grape'}>
+              <Anchor href={'/explore'} fw={500} c={'grape'}>
                 Explore cards from the community
               </Anchor>
             </Text>

--- a/src/webapp/features/home/components/recentCollections/RecentCollections.tsx
+++ b/src/webapp/features/home/components/recentCollections/RecentCollections.tsx
@@ -5,11 +5,11 @@ import CreateCollectionDrawer from '@/features/collections/components/createColl
 import useMyCollections from '@/features/collections/lib/queries/useMyCollections';
 import useMyProfile from '@/features/profile/lib/queries/useMyProfile';
 import { Stack, Button, Text, SimpleGrid, Group, Title } from '@mantine/core';
-import Link from 'next/link';
 import { Fragment, useState } from 'react';
 import { BiCollection } from 'react-icons/bi';
 import { FiPlus } from 'react-icons/fi';
 import { useUserSettings } from '@/features/settings/lib/queries/useUserSettings';
+import { LinkButton } from '@/components/link/MantineLink';
 
 export default function RecentCollections() {
   const { settings } = useUserSettings();
@@ -26,14 +26,13 @@ export default function RecentCollections() {
           <BiCollection size={22} />
           <Title order={2}>Collections</Title>
         </Group>
-        <Button
+        <LinkButton
           variant="light"
-          component={Link}
           color="blue"
           href={`/profile/${profile.handle}/collections`}
         >
           View all
-        </Button>
+        </LinkButton>
       </Group>
 
       {collections.length > 0 ? (

--- a/src/webapp/features/home/containers/homeContainer/HomeContainer.tsx
+++ b/src/webapp/features/home/containers/homeContainer/HomeContainer.tsx
@@ -1,5 +1,4 @@
-import { Container, Group, Stack, Title, Text, Button } from '@mantine/core';
-import Link from 'next/link';
+import { Container, Group, Stack, Title, Text } from '@mantine/core';
 import { MdOutlineEmojiNature } from 'react-icons/md';
 import DiscoverOnSemble from '../../components/discoverOnSemble/DiscoverOnSemble';
 import { ErrorBoundary } from 'react-error-boundary';
@@ -10,6 +9,7 @@ import DiscoverOnSembleSkeleton from '../../components/discoverOnSemble/Skeleton
 import RecentCardsSkeleton from '../../components/recentCards/Skeleton.RecentCards';
 import RecentCollectionsSkeleton from '../../components/recentCollections/Skeleton.RecentCollections';
 import AtmosphereConfBanner from '../../components/atmosphereConfBanner/AtmosphereConfBanner';
+import { LinkButton } from '@/components/link/MantineLink';
 
 export default function HomeContainer() {
   return (
@@ -28,14 +28,9 @@ export default function HomeContainer() {
                       <MdOutlineEmojiNature size={22} />
                       <Title order={2}>Discover on Semble</Title>
                     </Group>
-                    <Button
-                      variant="light"
-                      component={Link}
-                      color="blue"
-                      href={'/explore'}
-                    >
+                    <LinkButton variant="light" color="blue" href={'/explore'}>
                       View all
-                    </Button>
+                    </LinkButton>
                   </Group>
                   <Stack align="center" gap="xs">
                     <Text fz="h3" fw={600} c="gray">

--- a/src/webapp/features/notes/components/noteCard/NoteCard.tsx
+++ b/src/webapp/features/notes/components/noteCard/NoteCard.tsx
@@ -1,7 +1,7 @@
 import { User } from '@/api-client/ApiClient';
-import { Avatar, Card, Group, Spoiler, Stack, Text } from '@mantine/core';
+import { Card, Group, Spoiler, Stack, Text } from '@mantine/core';
 import { getRelativeTime } from '@/lib/utils/time';
-import Link from 'next/link';
+import { LinkAvatar, LinkText } from '@/components/link/MantineLink';
 
 interface Props {
   id: string;
@@ -21,8 +21,7 @@ export default function NoteCard(props: Props) {
         </Spoiler>
 
         <Group gap={'xs'}>
-          <Avatar
-            component={Link}
+          <LinkAvatar
             href={`/profile/${props.author.handle}`}
             src={props.author.avatarUrl?.replace('avatar', 'avatar_thumbnail')}
             alt={`${props.author.handle}'s avatar`}
@@ -30,15 +29,14 @@ export default function NoteCard(props: Props) {
           />
 
           <Text>
-            <Text
-              component={Link}
+            <LinkText
               href={`/profile/${props.author.handle}`}
               c={'bright'}
               fw={500}
               span
             >
               {props.author.name}
-            </Text>
+            </LinkText>
             <Text c={'gray'} span>
               {' · '}
             </Text>

--- a/src/webapp/features/notes/components/noteCardModal/NoteCardModalContent.tsx
+++ b/src/webapp/features/notes/components/noteCardModal/NoteCardModalContent.tsx
@@ -1,7 +1,6 @@
 import useGetCardFromMyLibrary from '@/features/cards/lib/queries/useGetCardFromMyLibrary';
 import {
   Anchor,
-  Avatar,
   Card,
   Group,
   Stack,
@@ -15,12 +14,12 @@ import {
   VisuallyHidden,
 } from '@mantine/core';
 import { UrlCard, User } from '@semble/types';
-import Link from 'next/link';
 import { Fragment, useState } from 'react';
 import useUpdateNote from '../../lib/mutations/useUpdateNote';
 import { notifications } from '@mantine/notifications';
 import useRemoveCardFromLibrary from '@/features/cards/lib/mutations/useRemoveCardFromLibrary';
 import { BsExclamation } from 'react-icons/bs';
+import { LinkAvatar } from '@/components/link/MantineLink';
 
 interface Props {
   onClose: () => void;
@@ -155,9 +154,8 @@ export default function NoteCardModalContent(props: Props) {
     <Stack gap={'xs'}>
       {props.cardAuthor && (
         <Group gap={5}>
-          <Avatar
+          <LinkAvatar
             size={'sm'}
-            component={Link}
             href={`/profile/${props.cardAuthor.handle}`}
             target="_blank"
             src={props.cardAuthor.avatarUrl?.replace(
@@ -167,7 +165,6 @@ export default function NoteCardModalContent(props: Props) {
             alt={`${props.cardAuthor.name}'s avatar`}
           />
           <Anchor
-            component={Link}
             href={`/profile/${props.cardAuthor.handle}`}
             target="_blank"
             fw={700}
@@ -199,7 +196,6 @@ export default function NoteCardModalContent(props: Props) {
               )}
               <Tooltip label={props.cardContent.url}>
                 <Anchor
-                  component={Link}
                   href={props.cardContent.url}
                   target="_blank"
                   c={'gray'}

--- a/src/webapp/features/notifications/components/notificationActivityStatus/NotificationActivityStatus.tsx
+++ b/src/webapp/features/notifications/components/notificationActivityStatus/NotificationActivityStatus.tsx
@@ -1,11 +1,9 @@
 import {
   Anchor,
-  Avatar,
   Card,
   Group,
   Menu,
   MenuDropdown,
-  MenuItem,
   MenuTarget,
   ScrollArea,
   Stack,
@@ -19,12 +17,16 @@ import {
   CollectionAccessType,
 } from '@/api-client';
 import { Fragment } from 'react';
-import Link from 'next/link';
 import styles from '../../../feeds/components/feedActivityStatus/FeedActivityStatus.module.css';
 import { getRelativeTime } from '@/lib/utils/time';
 import { getRecordKey } from '@/lib/utils/atproto';
 import { sanitizeText } from '@/lib/utils/text';
 import { getNotificationTypeIcon } from '../../lib/utils/icon';
+import {
+  LinkAvatar,
+  LinkMenuItem,
+  LinkText,
+} from '@/components/link/MantineLink';
 
 interface Props {
   user: NotificationItem['user'];
@@ -49,14 +51,9 @@ export default function NotificationActivityStatus(props: Props) {
     const remainingCount = collections.length - MAX_DISPLAYED;
 
     const userName = (
-      <Text
-        component={Link}
-        href={`/profile/${props.user.handle}`}
-        fw={600}
-        c={'bright'}
-      >
+      <LinkText href={`/profile/${props.user.handle}`} fw={600} c={'bright'}>
         {sanitizeText(props.user.name)}
-      </Text>
+      </LinkText>
     );
 
     switch (props.type) {
@@ -180,7 +177,6 @@ export default function NotificationActivityStatus(props: Props) {
       {displayedCollections.map((collection: Collection, index: number) => (
         <span key={collection.id}>
           <Anchor
-            component={Link}
             href={`/profile/${collection.author.handle}/collections/${getRecordKey(collection.uri!)}`}
             c={
               collection.accessType === CollectionAccessType.OPEN
@@ -211,16 +207,15 @@ export default function NotificationActivityStatus(props: Props) {
           <MenuDropdown maw={380}>
             <ScrollArea.Autosize mah={150} type="auto">
               {remainingCollections.map((c) => (
-                <MenuItem
+                <LinkMenuItem
                   key={c.id}
-                  component={Link}
                   href={`/profile/${c.author.handle}/collections/${getRecordKey(c.uri!)}`}
                   target="_blank"
                   c="grape"
                   fw={600}
                 >
                   {c.name}
-                </MenuItem>
+                </LinkMenuItem>
               ))}
             </ScrollArea.Autosize>
           </MenuDropdown>
@@ -239,8 +234,7 @@ export default function NotificationActivityStatus(props: Props) {
                 <TypeIcon size={12} />
               </ThemeIcon>
             )}
-            <Avatar
-              component={Link}
+            <LinkAvatar
               href={`/profile/${props.user.handle}`}
               src={props.user.avatarUrl?.replace('avatar', 'avatar_thumbnail')}
               alt={`${props.user.name}'s' avatar`}

--- a/src/webapp/features/platforms/bluesky/components/blueskyPost/BlueskyPost.tsx
+++ b/src/webapp/features/platforms/bluesky/components/blueskyPost/BlueskyPost.tsx
@@ -2,16 +2,7 @@
 
 import { AppBskyFeedDefs, AppBskyFeedPost } from '@atproto/api';
 import { ReactElement } from 'react';
-import {
-  Group,
-  Stack,
-  Text,
-  Avatar,
-  Box,
-  Image,
-  Anchor,
-  Tooltip,
-} from '@mantine/core';
+import { Group, Stack, Text, Box, Image, Anchor, Tooltip } from '@mantine/core';
 import RichTextRenderer from '@/components/contentDisplay/richTextRenderer/RichTextRenderer';
 import useGetBlueskyPost from '../../lib/queries/useGetBlueskyPost';
 import PostEmbed from '../postEmbed/PostEmbed';
@@ -28,7 +19,7 @@ import { getPostUriFromUrl } from '@/lib/utils/atproto';
 import BlackskyLogo from '@/assets/icons/blacksky-logo.svg';
 import BlackskyLogoWhite from '@/assets/icons/blacksky-logo-white.svg';
 import { useUserSettings } from '@/features/settings/lib/queries/useUserSettings';
-import Link from 'next/link';
+import { LinkAvatar } from '@/components/link/MantineLink';
 
 interface Props {
   url: string;
@@ -85,8 +76,7 @@ export default function BlueskyPost(props: Props) {
     <Stack justify="space-between" gap="xs">
       <Group gap="xs" justify="space-between" wrap="nowrap" w={'100%'}>
         <Group gap={'xs'} wrap="nowrap">
-          <Avatar
-            component={Link}
+          <LinkAvatar
             href={`https://bsky.app/profile/${post.author.handle}`}
             src={post.author.avatar?.replace('avatar', 'avatar_thumbnail')}
             alt={`${post.author.handle} avatar`}

--- a/src/webapp/features/platforms/bluesky/components/blueskySemblePost/BlueskySemblePost.tsx
+++ b/src/webapp/features/platforms/bluesky/components/blueskySemblePost/BlueskySemblePost.tsx
@@ -11,12 +11,10 @@ import {
   Anchor,
   Card,
   Group,
-  Avatar,
   Box,
   Image,
   Text,
 } from '@mantine/core';
-import Link from 'next/link';
 import { FaBluesky } from 'react-icons/fa6';
 import PostEmbed from '../postEmbed/PostEmbed';
 import ContentHider from '../contentHider/ContentHider';
@@ -31,6 +29,7 @@ import UrlTypeBadge from '@/features/semble/components/urlTypeBadge/UrlTypeBadge
 import UrlTypeBadgeSkeleton from '@/features/semble/components/urlTypeBadge/Skeleton.UrlTypeBadge';
 import { isBotAccount } from '../../lib/utils/account';
 import BotLabel from '@/features/profile/components/botLabel/BotLabel';
+import { LinkAvatar } from '@/components/link/MantineLink';
 
 interface Props {
   url: string;
@@ -92,8 +91,7 @@ export default async function BlueskySemblePost(props: Props) {
         <Stack gap={'xs'}>
           <Group gap="xs" justify="space-between" wrap="nowrap">
             <Group gap={'xs'} wrap="nowrap">
-              <Avatar
-                component={Link}
+              <LinkAvatar
                 href={`https://bsky.app/profile/${post.author.handle}`}
                 src={post.author.avatar?.replace('avatar', 'avatar_thumbnail')}
                 alt={`${post.author.handle} social preview image`}

--- a/src/webapp/features/platforms/bluesky/components/externalEmbed/ExternalEmbed.tsx
+++ b/src/webapp/features/platforms/bluesky/components/externalEmbed/ExternalEmbed.tsx
@@ -14,7 +14,6 @@ import {
   Text,
 } from '@mantine/core';
 
-
 interface Props {
   embed: AppBskyEmbedExternal.View;
 }

--- a/src/webapp/features/platforms/bluesky/components/externalEmbed/ExternalEmbed.tsx
+++ b/src/webapp/features/platforms/bluesky/components/externalEmbed/ExternalEmbed.tsx
@@ -13,7 +13,7 @@ import {
   Stack,
   Text,
 } from '@mantine/core';
-import Link from 'next/link';
+
 
 interface Props {
   embed: AppBskyEmbedExternal.View;
@@ -43,7 +43,6 @@ export default function ExternalEmbed(props: Props) {
               {props.embed.external.title}
             </Text>
             <Anchor
-              component={Link}
               href={props.embed.external.uri}
               fz={'sm'}
               fw={500}

--- a/src/webapp/features/platforms/common/components/IframeEmbed/IframeEmbed.tsx
+++ b/src/webapp/features/platforms/common/components/IframeEmbed/IframeEmbed.tsx
@@ -12,7 +12,6 @@ import { UrlCard } from '@semble/types';
 
 import { Fragment } from 'react';
 
-
 interface IframeEmbedProps {
   url: string;
   cardContent: UrlCard['cardContent'];

--- a/src/webapp/features/platforms/common/components/IframeEmbed/IframeEmbed.tsx
+++ b/src/webapp/features/platforms/common/components/IframeEmbed/IframeEmbed.tsx
@@ -9,8 +9,9 @@ import {
   MantineRadius,
 } from '@mantine/core';
 import { UrlCard } from '@semble/types';
-import Link from 'next/link';
+
 import { Fragment } from 'react';
+
 
 interface IframeEmbedProps {
   url: string;
@@ -41,7 +42,6 @@ export default function IframeEmbed(props: IframeEmbedProps) {
         <Tooltip label={props.cardContent.url}>
           <Anchor
             onClick={(e) => e.stopPropagation()}
-            component={Link}
             href={props.cardContent.url}
             target="_blank"
             c={'gray'}

--- a/src/webapp/features/profile/components/profileCard/ProfileCard.tsx
+++ b/src/webapp/features/profile/components/profileCard/ProfileCard.tsx
@@ -1,8 +1,8 @@
-import { Avatar, Badge, Card, Group, Stack, Text } from '@mantine/core';
+import { Avatar, Badge, Group, Stack, Text } from '@mantine/core';
 import { User } from '@semble/types';
-import Link from 'next/link';
 import { sanitizeText } from '@/lib/utils/text';
 import { ReactNode } from 'react';
+import { LinkCard } from '@/components/link/MantineLink';
 
 interface Props {
   profile: User;
@@ -11,11 +11,10 @@ interface Props {
 
 export default function ProfileCard(props: Props) {
   return (
-    <Card
+    <LinkCard
       withBorder
       radius={'lg'}
       p={'sm'}
-      component={Link}
       href={`/profile/${props.profile.handle}`}
       h={'100%'}
     >
@@ -51,6 +50,6 @@ export default function ProfileCard(props: Props) {
           </Text>
         )}
       </Stack>
-    </Card>
+    </LinkCard>
   );
 }

--- a/src/webapp/features/profile/components/profileFollowStats/ProfileFollowStats.tsx
+++ b/src/webapp/features/profile/components/profileFollowStats/ProfileFollowStats.tsx
@@ -6,7 +6,6 @@ import { useSuspenseQuery } from '@tanstack/react-query';
 import { profileKeys } from '../../lib/profileKeys';
 import { getProfile } from '../../lib/dal';
 
-
 interface Props {
   handle: string;
   initialFollowerCount: number;
@@ -27,10 +26,7 @@ export default function ProfileFollowStats(props: Props) {
 
   return (
     <Group gap="sm">
-      <Anchor
-        href={`/profile/${props.handle}/network`}
-        underline="never"
-      >
+      <Anchor href={`/profile/${props.handle}/network`} underline="never">
         <Text fw={500} c={'bright'} span>
           {followerCount}
         </Text>

--- a/src/webapp/features/profile/components/profileFollowStats/ProfileFollowStats.tsx
+++ b/src/webapp/features/profile/components/profileFollowStats/ProfileFollowStats.tsx
@@ -1,10 +1,11 @@
 'use client';
 
 import { Group, Anchor, Text } from '@mantine/core';
-import Link from 'next/link';
+
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { profileKeys } from '../../lib/profileKeys';
 import { getProfile } from '../../lib/dal';
+
 
 interface Props {
   handle: string;
@@ -27,7 +28,6 @@ export default function ProfileFollowStats(props: Props) {
   return (
     <Group gap="sm">
       <Anchor
-        component={Link}
         href={`/profile/${props.handle}/network`}
         underline="never"
       >
@@ -41,7 +41,6 @@ export default function ProfileFollowStats(props: Props) {
       </Anchor>
 
       <Anchor
-        component={Link}
         href={`/profile/${props.handle}/network/following`}
         underline="never"
       >
@@ -54,7 +53,6 @@ export default function ProfileFollowStats(props: Props) {
       </Anchor>
 
       <Anchor
-        component={Link}
         href={`/profile/${props.handle}/network/collections-following`}
         underline="never"
       >

--- a/src/webapp/features/profile/components/profileHeader/MinimalProfileHeader.tsx
+++ b/src/webapp/features/profile/components/profileHeader/MinimalProfileHeader.tsx
@@ -1,16 +1,8 @@
 import BackButton from '@/components/navigation/backButton/BackButton';
 import NavbarToggle from '@/components/navigation/NavbarToggle';
-import {
-  Group,
-  Avatar,
-  Stack,
-  Title,
-  Text,
-  Container,
-  ActionIcon,
-} from '@mantine/core';
-import Link from 'next/link';
+import { Group, Avatar, Stack, Title, Text, Container } from '@mantine/core';
 import { IoSearch } from 'react-icons/io5';
+import { LinkActionIcon } from '@/components/link/MantineLink';
 
 interface Props {
   avatarUrl?: string;
@@ -41,8 +33,7 @@ export default function MinimalProfileHeader(props: Props) {
         </Group>
 
         <Group gap={'xs'} wrap="nowrap">
-          <ActionIcon
-            component={Link}
+          <LinkActionIcon
             href={`/search/cards?handle=${props.handle}`}
             variant="light"
             color="gray"
@@ -50,7 +41,7 @@ export default function MinimalProfileHeader(props: Props) {
             radius={'xl'}
           >
             <IoSearch />
-          </ActionIcon>
+          </LinkActionIcon>
           <NavbarToggle />
         </Group>
       </Group>

--- a/src/webapp/features/profile/components/profileHeader/ProfileHeader.tsx
+++ b/src/webapp/features/profile/components/profileHeader/ProfileHeader.tsx
@@ -21,8 +21,8 @@ import { verifySessionOnServer } from '@/lib/auth/dal.server';
 import FollowButton from '@/features/follows/components/followButton/FollowButton';
 import ProfileFollowStats from '../profileFollowStats/ProfileFollowStats';
 import FollowStatsSkeleton from '../profileFollowStats/Skeleton.FollowStats';
-import Link from 'next/link';
 import { IoSearch } from 'react-icons/io5';
+import { LinkActionIcon } from '@/components/link/MantineLink';
 
 interface Props {
   handle: string;
@@ -69,8 +69,7 @@ export default async function ProfileHeader(props: Props) {
                     initialIsFollowing={profile.isFollowing}
                   />
                 )}
-                <ActionIcon
-                  component={Link}
+                <LinkActionIcon
                   href={`/search/cards?handle=${props.handle}`}
                   variant="light"
                   color="gray"
@@ -78,7 +77,7 @@ export default async function ProfileHeader(props: Props) {
                   radius={'xl'}
                 >
                   <IoSearch />
-                </ActionIcon>
+                </LinkActionIcon>
               </Group>
             </Group>
 

--- a/src/webapp/features/profile/components/profileHoverCard/ProfileHoverCard.tsx
+++ b/src/webapp/features/profile/components/profileHoverCard/ProfileHoverCard.tsx
@@ -1,7 +1,6 @@
 import {
   Anchor,
   Avatar,
-  Button,
   Group,
   HoverCard,
   HoverCardDropdown,
@@ -13,8 +12,8 @@ import {
 import useProfile from '../../lib/queries/useProfile';
 import { BiCollection } from 'react-icons/bi';
 import { FaRegNoteSticky } from 'react-icons/fa6';
-import Link from 'next/link';
 import RichTextRenderer from '@/components/contentDisplay/richTextRenderer/RichTextRenderer';
+import { LinkButton } from '@/components/link/MantineLink';
 
 interface Props {
   children: React.ReactNode;
@@ -62,7 +61,6 @@ export default function ProfileHoverCard(props: Props) {
             {/* Follow stats */}
             <Group gap="xs">
               <Anchor
-                component={Link}
                 href={`/profile/${profile.handle}/network`}
                 underline="never"
               >
@@ -76,7 +74,6 @@ export default function ProfileHoverCard(props: Props) {
               </Anchor>
 
               <Anchor
-                component={Link}
                 href={`/profile/${profile.handle}/network/following`}
                 underline="never"
               >
@@ -92,24 +89,22 @@ export default function ProfileHoverCard(props: Props) {
               <RichTextRenderer text={profile.description} />
             )}
             <Group gap={'xs'} grow>
-              <Button
-                component={Link}
+              <LinkButton
                 href={`/profile/${profile.handle}/cards`}
                 variant="light"
                 color="gray"
                 leftSection={<FaRegNoteSticky />}
               >
                 Cards
-              </Button>
-              <Button
-                component={Link}
+              </LinkButton>
+              <LinkButton
                 href={`/profile/${profile.handle}/collections`}
                 variant="light"
                 color={'grape'}
                 leftSection={<BiCollection />}
               >
                 Collections
-              </Button>
+              </LinkButton>
             </Group>
           </Stack>
         )}

--- a/src/webapp/features/profile/containers/profileContainer/ProfileContainer.tsx
+++ b/src/webapp/features/profile/containers/profileContainer/ProfileContainer.tsx
@@ -11,9 +11,7 @@ import {
   Stack,
   Title,
   Grid,
-  Button,
 } from '@mantine/core';
-import Link from 'next/link';
 import ProfileEmptyTab from '../../components/profileEmptyTab/ProfileEmptyTab';
 import { BiCollection } from 'react-icons/bi';
 import { FaRegNoteSticky } from 'react-icons/fa6';
@@ -21,6 +19,7 @@ import { useNavbarContext } from '@/providers/navbar';
 import { CardSaveSource } from '@/features/analytics/types';
 import { useUserSettings } from '@/features/settings/lib/queries/useUserSettings';
 import { usePathname } from 'next/navigation';
+import { LinkButton } from '@/components/link/MantineLink';
 
 interface Props {
   handle: string;
@@ -52,14 +51,13 @@ export default function ProfileContainer(props: Props) {
               <Title order={2} fz={'h3'}>
                 Cards
               </Title>
-              <Button
+              <LinkButton
                 variant="light"
-                component={Link}
                 color="blue"
                 href={`/profile/${props.handle}/cards`}
               >
                 View all
-              </Button>
+              </LinkButton>
             </Group>
 
             {cards.length > 0 ? (
@@ -106,14 +104,13 @@ export default function ProfileContainer(props: Props) {
               <Title order={2} fz={'h3'}>
                 Collections
               </Title>
-              <Button
+              <LinkButton
                 variant="light"
-                component={Link}
                 color="blue"
                 href={`/profile/${props.handle}/collections`}
               >
                 View all
-              </Button>
+              </LinkButton>
             </Group>
 
             {collections.length > 0 ? (

--- a/src/webapp/features/search/components/profileCard/SearchProfileCard.tsx
+++ b/src/webapp/features/search/components/profileCard/SearchProfileCard.tsx
@@ -1,6 +1,6 @@
 import { ProfileView } from '@/api-client';
-import { Avatar, Badge, Card, Group, Stack, Text } from '@mantine/core';
-import Link from 'next/link';
+import { Avatar, Badge, Group, Stack, Text } from '@mantine/core';
+import { LinkCard } from '@/components/link/MantineLink';
 
 interface Props {
   profile: ProfileView;
@@ -8,11 +8,10 @@ interface Props {
 
 export default function SearchProfileCard(props: Props) {
   return (
-    <Card
+    <LinkCard
       withBorder
       radius={'lg'}
       p={'sm'}
-      component={Link}
       href={`/profile/${props.profile.handle}`}
       h={'100%'}
     >
@@ -45,6 +44,6 @@ export default function SearchProfileCard(props: Props) {
           </Text>
         )}
       </Stack>
-    </Card>
+    </LinkCard>
   );
 }

--- a/src/webapp/features/search/containers/searchContainer/Error.SearchContainer.tsx
+++ b/src/webapp/features/search/containers/searchContainer/Error.SearchContainer.tsx
@@ -1,19 +1,14 @@
-import { Alert, Button, Container } from '@mantine/core';
-import Link from 'next/link';
+import { Alert, Container } from '@mantine/core';
 import { IoArrowBack } from 'react-icons/io5';
+import { LinkButton } from '@/components/link/MantineLink';
 
 export default function SearchContainerError() {
   return (
     <Container p="xs" size="xl">
       <Alert color="red" title="Could not load search page">
-        <Button
-          color="red"
-          component={Link}
-          href={'/search'}
-          leftSection={<IoArrowBack />}
-        >
+        <LinkButton color="red" href={'/search'} leftSection={<IoArrowBack />}>
           Go to search
-        </Button>
+        </LinkButton>
       </Alert>
     </Container>
   );

--- a/src/webapp/features/semble/components/sembleActions/GusetSembleActions.tsx
+++ b/src/webapp/features/semble/components/sembleActions/GusetSembleActions.tsx
@@ -1,10 +1,10 @@
 'use client';
 
-import { ActionIcon, Button, CopyButton, Group, Tooltip } from '@mantine/core';
-import Link from 'next/link';
+import { ActionIcon, CopyButton, Group, Tooltip } from '@mantine/core';
 import { MdIosShare } from 'react-icons/md';
 import { notifications } from '@mantine/notifications';
 import { TbPlugConnected } from 'react-icons/tb';
+import { LinkButton } from '@/components/link/MantineLink';
 
 interface Props {
   url: string;
@@ -46,8 +46,7 @@ export default function GuestSembleActions(props: Props) {
           </Tooltip>
         )}
       </CopyButton>
-      <Button
-        component={Link}
+      <LinkButton
         href={'/login'}
         variant="light"
         color="green"
@@ -55,10 +54,8 @@ export default function GuestSembleActions(props: Props) {
         leftSection={<TbPlugConnected size={18} />}
       >
         Log in to connect
-      </Button>
-      <Button component={Link} href={'/login'}>
-        Log in to add
-      </Button>
+      </LinkButton>
+      <LinkButton href={'/login'}>Log in to add</LinkButton>
     </Group>
   );
 }

--- a/src/webapp/features/semble/components/urlAddedBySummary/UrlAddedBySummary.tsx
+++ b/src/webapp/features/semble/components/urlAddedBySummary/UrlAddedBySummary.tsx
@@ -1,7 +1,7 @@
-import { Avatar, AvatarGroup, Group, Text, Anchor } from '@mantine/core';
-import Link from 'next/link';
+import { AvatarGroup, Group, Text, Anchor } from '@mantine/core';
 import { getLibrariesForUrl } from '../../lib/dal';
 import { sanitizeText } from '@/lib/utils/text';
+import { LinkAvatar } from '@/components/link/MantineLink';
 
 interface Props {
   url: string;
@@ -22,9 +22,8 @@ export default async function UrlAddedBySummary(props: Props) {
     <Group gap={'xs'}>
       <AvatarGroup>
         {shownUsers.map((p, i) => (
-          <Avatar
+          <LinkAvatar
             key={i}
-            component={Link}
             href={`/profile/${p.user.handle}`}
             src={p.user.avatarUrl?.replace('avatar', 'avatar_thumbnail')}
             alt={p.user.handle}
@@ -39,7 +38,6 @@ export default async function UrlAddedBySummary(props: Props) {
         {shownUsers.map((p, i) => (
           <Anchor
             key={p.user.handle}
-            component={Link}
             href={`/profile/${p.user.handle}`}
             fz={'sm'}
             fw={600}

--- a/src/webapp/features/semble/components/urlMetadataHeader/UrlMetadataHeader.tsx
+++ b/src/webapp/features/semble/components/urlMetadataHeader/UrlMetadataHeader.tsx
@@ -1,7 +1,8 @@
 import { getUrlMetadata } from '@/features/cards/lib/dal';
 import { Stack, Anchor, Title, Text, Spoiler } from '@mantine/core';
-import Link from 'next/link';
+
 import UrlTypeBadge from '../urlTypeBadge/UrlTypeBadge';
+
 
 interface Props {
   url: string;
@@ -16,7 +17,6 @@ export default async function UrlMetadataHeader(props: Props) {
         <UrlTypeBadge url={props.url} />
         {metadata.title && (
           <Anchor
-            component={Link}
             href={metadata.url}
             target="_blank"
             c={'inherit'}

--- a/src/webapp/features/semble/components/urlMetadataHeader/UrlMetadataHeader.tsx
+++ b/src/webapp/features/semble/components/urlMetadataHeader/UrlMetadataHeader.tsx
@@ -3,7 +3,6 @@ import { Stack, Anchor, Title, Text, Spoiler } from '@mantine/core';
 
 import UrlTypeBadge from '../urlTypeBadge/UrlTypeBadge';
 
-
 interface Props {
   url: string;
 }

--- a/src/webapp/features/semble/components/urlMetadataHeader/UrlMetadataImage.tsx
+++ b/src/webapp/features/semble/components/urlMetadataHeader/UrlMetadataImage.tsx
@@ -1,6 +1,6 @@
 import { getUrlMetadata } from '@/features/cards/lib/dal';
-import { Image, Card } from '@mantine/core';
-import Link from 'next/link';
+import { Image } from '@mantine/core';
+import { LinkCard } from '@/components/link/MantineLink';
 
 interface Props {
   url: string;
@@ -12,14 +12,7 @@ export default async function UrlMetadataImage(props: Props) {
   if (!metadata.imageUrl) return null;
 
   return (
-    <Card
-      p={0}
-      radius={'md'}
-      component={Link}
-      href={props.url}
-      target="_blank"
-      withBorder
-    >
+    <LinkCard p={0} radius={'md'} href={props.url} target="_blank" withBorder>
       <Image
         src={metadata.imageUrl}
         alt={`${props.url} social preview image`}
@@ -28,6 +21,6 @@ export default async function UrlMetadataImage(props: Props) {
         maw={280}
         fit="contain"
       />
-    </Card>
+    </LinkCard>
   );
 }

--- a/src/webapp/features/semble/components/urlTypeBadge/UrlTypeBadge.tsx
+++ b/src/webapp/features/semble/components/urlTypeBadge/UrlTypeBadge.tsx
@@ -5,7 +5,6 @@ import { RiArrowRightUpLine } from 'react-icons/ri';
 import { Suspense } from 'react';
 import UrlTypeBadgeContent from './UrlTypeBadgeContent';
 
-
 interface Props {
   url: string;
 }

--- a/src/webapp/features/semble/components/urlTypeBadge/UrlTypeBadge.tsx
+++ b/src/webapp/features/semble/components/urlTypeBadge/UrlTypeBadge.tsx
@@ -1,9 +1,10 @@
 import { getDomain } from '@/lib/utils/link';
 import { Tooltip, Anchor, Group, Skeleton } from '@mantine/core';
-import Link from 'next/link';
+
 import { RiArrowRightUpLine } from 'react-icons/ri';
 import { Suspense } from 'react';
 import UrlTypeBadgeContent from './UrlTypeBadgeContent';
+
 
 interface Props {
   url: string;
@@ -17,7 +18,6 @@ export default function UrlTypeBadge({ url }: Props) {
       </Suspense>
       <Tooltip label={url}>
         <Anchor
-          component={Link}
           target="_blank"
           fw={700}
           c="blue"

--- a/src/webapp/features/settings/components/accountSummary/AccountSummary.tsx
+++ b/src/webapp/features/settings/components/accountSummary/AccountSummary.tsx
@@ -1,7 +1,7 @@
-import { Avatar, Stack, Text } from '@mantine/core';
-import Link from 'next/link';
+import { Stack, Text } from '@mantine/core';
 import { createServerSembleClient } from '@/services/server.apiClient';
 import { verifySessionOnServer } from '@/lib/auth/dal.server';
+import { LinkAvatar } from '@/components/link/MantineLink';
 
 export default async function AccountSummary() {
   await verifySessionOnServer({ redirectOnFail: true });
@@ -11,8 +11,7 @@ export default async function AccountSummary() {
 
   return (
     <Stack gap={'xs'} align="center">
-      <Avatar
-        component={Link}
+      <LinkAvatar
         href={`/profile/${profile.handle}`}
         src={profile.avatarUrl?.replace('avatar', 'avatar_thumbnail')}
         alt={`${profile.name}'s avatar`}

--- a/src/webapp/features/settings/components/settingItem/SettingItem.tsx
+++ b/src/webapp/features/settings/components/settingItem/SettingItem.tsx
@@ -1,7 +1,6 @@
 import type { IconType } from 'react-icons/lib';
-import { Button } from '@mantine/core';
-import Link from 'next/link';
 import { isValidElement } from 'react';
+import { LinkButton } from '@/components/link/MantineLink';
 
 interface Props {
   href: string;
@@ -18,8 +17,7 @@ export default function SettingItem(props: Props) {
   };
 
   return (
-    <Button
-      component={Link}
+    <LinkButton
       href={props.href}
       target={props.openInNewTab ? '_blank' : '_self'}
       variant="light"
@@ -31,6 +29,6 @@ export default function SettingItem(props: Props) {
       my={1}
     >
       {props.children}
-    </Button>
+    </LinkButton>
   );
 }

--- a/src/webapp/features/url/containers/urlEmbedContainer/UrlEmbedContainer.tsx
+++ b/src/webapp/features/url/containers/urlEmbedContainer/UrlEmbedContainer.tsx
@@ -9,10 +9,7 @@ import {
   Card,
   Badge,
   Box,
-  ActionIcon,
 } from '@mantine/core';
-import SembleLogo from '@/assets/semble-logo.svg';
-import Link from 'next/link';
 import { LuLibrary } from 'react-icons/lu';
 import { MdOutlineStickyNote2 } from 'react-icons/md';
 import { BiCollection, BiLink } from 'react-icons/bi';
@@ -22,6 +19,8 @@ import { useRouter } from 'next/navigation';
 import { isCollectionPage, isProfilePage } from '@/lib/utils/link';
 import SembleHeaderBackground from '@/features/semble/containers/sembleContainer/SembleHeaderBackground';
 import UrlEmbedContainerSkeleton from './skeleton.UrlEmbedContainer';
+import { LinkActionIcon } from '@/components/link/MantineLink';
+import SembleLogo from '@/assets/semble-logo.svg';
 
 interface Props {
   url: string;
@@ -64,16 +63,15 @@ export default function UrlEmbedContainer(props: Props) {
     <Container p={0} fluid h="100%" style={{ overflow: 'hidden' }}>
       <SembleHeaderBackground height={40}>
         <Box mx={'xs'} my={6}>
-          <ActionIcon
+          <LinkActionIcon
             size="compact-xs"
             variant="transparent"
             radius={'xs'}
-            component={Link}
             href={`${appUrl}/url?id=${encodeURIComponent(props.url)}`}
             target="_blank"
           >
             <Image src={SembleLogo.src} h={24} />
-          </ActionIcon>
+          </LinkActionIcon>
         </Box>
       </SembleHeaderBackground>
       <Stack justify="space-between" h="100%">

--- a/src/webapp/mdx-components.tsx
+++ b/src/webapp/mdx-components.tsx
@@ -1,6 +1,6 @@
 import { Title, Text, List, ListItem, Anchor } from '@mantine/core';
 import type { MDXComponents } from 'mdx/types';
-import Link from 'next/link';
+
 
 const components: MDXComponents = {
   h1: ({ children }) => <Title order={1}>{children}</Title>,
@@ -9,7 +9,7 @@ const components: MDXComponents = {
   h4: ({ children }) => <Title order={4}>{children}</Title>,
   p: ({ children }) => <Text fw={500}>{children}</Text>,
   a: ({ children, href }) => (
-    <Anchor component={Link} href={href} c="blue" fw={600}>
+    <Anchor href={href} c="blue" fw={600}>
       {children}
     </Anchor>
   ),

--- a/src/webapp/mdx-components.tsx
+++ b/src/webapp/mdx-components.tsx
@@ -1,7 +1,6 @@
 import { Title, Text, List, ListItem, Anchor } from '@mantine/core';
 import type { MDXComponents } from 'mdx/types';
 
-
 const components: MDXComponents = {
   h1: ({ children }) => <Title order={1}>{children}</Title>,
   h2: ({ children }) => <Title order={2}>{children}</Title>,

--- a/src/webapp/next-env.d.ts
+++ b/src/webapp/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-/// <reference path="./.next/types/routes.d.ts" />
+import "./.next/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/src/webapp/next-env.d.ts
+++ b/src/webapp/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import './.next/types/routes.d.ts';
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/src/webapp/next.config.mjs
+++ b/src/webapp/next.config.mjs
@@ -3,11 +3,9 @@ import createMDX from '@next/mdx';
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   reactStrictMode: false,
-
   // Configure `pageExtensions` to include markdown and MDX files
   pageExtensions: ['js', 'jsx', 'md', 'mdx', 'ts', 'tsx'],
-  // Optionally, add any other Next.js config below
-
+  allowedDevOrigins: ['127.0.0.1'],
   experimental: {
     optimizePackageImports: [
       '@mantine/core',

--- a/src/webapp/package.json
+++ b/src/webapp/package.json
@@ -36,16 +36,16 @@
     "@mantine/notifications": "8.3.1",
     "@mdx-js/loader": "^3.1.1",
     "@mdx-js/react": "^3.1.1",
-    "@next/mdx": "^15.5.4",
+    "@next/mdx": "16.2.3",
     "@semble/types": "*",
     "@tanstack/react-query": "^5.85.5",
     "@types/mdx": "^2.0.13",
     "@vercel/analytics": "^1.5.0",
     "date-fns": "^4.1.0",
     "dayjs": "^1.11.13",
-    "next": "^15.4.10",
-    "react": "19.1.0",
-    "react-dom": "19.1.0",
+    "next": "16.2.3",
+    "react": "19.2.5",
+    "react-dom": "19.2.5",
     "react-error-boundary": "^6.0.0",
     "react-force-graph": "^1.48.2",
     "react-force-graph-2d": "^1.29.1",
@@ -62,12 +62,12 @@
     "@storybook/nextjs-vite": "^9.1.2",
     "@types/chrome": "^0.0.332",
     "@types/node": "^20.10.4",
-    "@types/react": "19.1.8",
-    "@types/react-dom": "19.1.6",
+    "@types/react": "19.2.14",
+    "@types/react-dom": "19.2.3",
     "@vitest/coverage-v8": "^3.2.4",
     "autoprefixer": "^10.4.16",
-    "eslint": "^8.55.0",
-    "eslint-config-next": "15.4.1",
+    "eslint": "^9.0.0",
+    "eslint-config-next": "16.2.3",
     "plasmo": "^0.90.5",
     "postcss": "^8.5.6",
     "postcss-preset-mantine": "^1.18.0",
@@ -79,7 +79,7 @@
     "vitest": "^3.2.4"
   },
   "overrides": {
-    "@types/react": "19.1.8",
-    "@types/react-dom": "19.1.6"
+    "@types/react": "19.2.14",
+    "@types/react-dom": "19.2.3"
   }
 }

--- a/src/webapp/styles/theme.tsx
+++ b/src/webapp/styles/theme.tsx
@@ -1,4 +1,5 @@
 'use client';
+import Link from 'next/link';
 import classes from './global.module.css';
 
 import {
@@ -18,6 +19,7 @@ import {
   Notification,
   Menu,
   SegmentedControl,
+  Anchor,
 } from '@mantine/core';
 
 export const theme = createTheme({
@@ -108,6 +110,11 @@ export const theme = createTheme({
       defaultProps: {
         fz: 'md',
         fw: 600,
+      },
+    }),
+    Anchor: Anchor.extend({
+      defaultProps: {
+        component: Link,
       },
     }),
     CheckboxIndicator: CheckboxIndicator.extend({

--- a/src/webapp/tsconfig.json
+++ b/src/webapp/tsconfig.json
@@ -1,11 +1,7 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -24,13 +20,9 @@
       }
     ],
     "paths": {
-      "@/*": [
-        "./*"
-      ]
+      "@/*": ["./*"]
     },
-    "types": [
-      "chrome"
-    ]
+    "types": ["chrome"]
   },
   "include": [
     ".plasmo/index.d.ts",
@@ -40,7 +32,5 @@
     ".next/types/**/*.ts",
     ".next/dev/types/**/*.ts"
   ],
-  "exclude": [
-    "node_modules"
-  ]
+  "exclude": ["node_modules"]
 }

--- a/src/webapp/tsconfig.json
+++ b/src/webapp/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -12,7 +16,7 @@
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "preserve",
+    "jsx": "react-jsx",
     "incremental": true,
     "plugins": [
       {
@@ -20,16 +24,23 @@
       }
     ],
     "paths": {
-      "@/*": ["./*"]
+      "@/*": [
+        "./*"
+      ]
     },
-    "types": ["chrome"]
+    "types": [
+      "chrome"
+    ]
   },
   "include": [
     ".plasmo/index.d.ts",
     "next-env.d.ts",
     "**/*.ts",
     "**/*.tsx",
-    ".next/types/**/*.ts"
+    ".next/types/**/*.ts",
+    ".next/dev/types/**/*.ts"
   ],
-  "exclude": ["node_modules"]
+  "exclude": [
+    "node_modules"
+  ]
 }


### PR DESCRIPTION
Mostly fixes [this issue with links](https://github.com/orgs/mantinedev/discussions/8629#discussioncomment-15579850) by creating wrapper components. Not ideal, but we do want to use `<Link>`, so it's tolerable 