### PR TITLE
fix: stale viaCardId causes login redirect when re-adding a deleted card

### DIFF
--- a/src/modules/cards/domain/services/CardLibraryService.ts
+++ b/src/modules/cards/domain/services/CardLibraryService.ts
@@ -96,10 +96,9 @@ export class CardLibraryService implements DomainService {
         }
         const viaCardValue = viaCardResult.value;
 
-        if (!viaCardValue) {
-          return err(new CardLibraryValidationError(`Via card not found`));
+        if (viaCardValue) {
+          viaCardPublishedRecordId = viaCardValue.publishedRecordId;
         }
-        viaCardPublishedRecordId = viaCardValue.publishedRecordId;
       }
 
       if (libraryInfo?.publishedRecordId) {
@@ -218,10 +217,9 @@ export class CardLibraryService implements DomainService {
         }
         const viaCardValue = viaCardResult.value;
 
-        if (!viaCardValue) {
-          return err(new CardLibraryValidationError(`Via card not found`));
+        if (viaCardValue) {
+          viaCardPublishedRecordId = viaCardValue.publishedRecordId;
         }
-        viaCardPublishedRecordId = viaCardValue.publishedRecordId;
       }
 
       if (isInLibrary && libraryInfo?.publishedRecordId) {


### PR DESCRIPTION
This fixes the issue where deleting a card and re-adding it from the semble page would redirect the user to the login page

When a user navigated to a semble page from their own card, deleted it, then tried to re-add it, the stale viaCardId (pointing to the just-deleted card) caused the server to reject the request with Via card not found

The fix: Save the card without the attribution link if it doesn't exist and don't throw an error