### PR TITLE
make packages output as ESM

### DIFF
--- a/src/contract/tsconfig.json
+++ b/src/contract/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "compilerOptions": {
     "target": "ES2020",
-    "module": "CommonJS",
+    "module": "esnext",
+    "moduleResolution": "bundler",
     "lib": ["ES2020"],
     "outDir": "./dist",
     "rootDir": "./src",

--- a/src/types/tsconfig.json
+++ b/src/types/tsconfig.json
@@ -1,7 +1,8 @@
 {
   "compilerOptions": {
     "target": "ES2020",
-    "module": "CommonJS",
+    "module": "esnext",
+    "moduleResolution": "bundler",
     "lib": ["ES2020"],
     "outDir": "./dist",
     "rootDir": "./src",


### PR DESCRIPTION
Bundling these internals packages as CJS instead of ESM was causing downstream effects when pulling in the `@semble.so/api` package. 