### PR TITLE
fix: paginate collection selector lists in add modal

### DIFF
--- a/src/webapp/components/contentDisplay/infiniteScroll/InfiniteScroll.tsx
+++ b/src/webapp/components/contentDisplay/infiniteScroll/InfiniteScroll.tsx
@@ -13,6 +13,7 @@ interface Props {
   loadMore: () => void;
   loader?: ReactNode;
   manualLoadButton?: boolean;
+  hideEndIndicator?: boolean;
 }
 
 export default function InfiniteScroll(props: Props) {
@@ -51,11 +52,14 @@ export default function InfiniteScroll(props: Props) {
         )}
       </Center>
 
-      {!props.hasMore && !isLoading && props.dataLength !== 0 && (
-        <Center mt={'xl'}>
-          <Divider variant="dashed" label="The end" w={120} />
-        </Center>
-      )}
+      {!props.hasMore &&
+        !isLoading &&
+        props.dataLength !== 0 &&
+        !props.hideEndIndicator && (
+          <Center mt={'xl'}>
+            <Divider variant="dashed" label="The end" w={120} />
+          </Center>
+        )}
     </Stack>
   );
 }

--- a/src/webapp/features/collections/components/collectionSelectorBrowseList/CollectionSelectorBrowseList.tsx
+++ b/src/webapp/features/collections/components/collectionSelectorBrowseList/CollectionSelectorBrowseList.tsx
@@ -1,0 +1,49 @@
+import { Fragment } from 'react';
+import { Alert, Divider, Stack, Text } from '@mantine/core';
+import CollectionSelectorItemList from '../collectionSelectorItemList/CollectionSelectorItemList';
+import { Collection } from '@semble/types';
+
+interface Props {
+  selectedCollections: Collection[];
+  unselectedCollections: Collection[];
+  onChange: (checked: boolean, item: Collection) => void;
+  emptyMessage: string;
+}
+
+export default function CollectionSelectorBrowseList(props: Props) {
+  const hasSelectedCollections = props.selectedCollections.length > 0;
+
+  return (
+    <Stack gap={'xs'}>
+      {/* selected collections */}
+      {hasSelectedCollections && (
+        <Fragment>
+          <Text fw={600} fz={'sm'} c={'gray'}>
+            Selected Collections ({props.selectedCollections.length})
+          </Text>
+          <CollectionSelectorItemList
+            collections={props.selectedCollections}
+            selectedCollections={props.selectedCollections}
+            onChange={props.onChange}
+          />
+          {props.unselectedCollections.length > 0 && (
+            <Divider variant="dashed" my="xs" />
+          )}
+        </Fragment>
+      )}
+
+      {/* remaining collections */}
+      {props.unselectedCollections.length > 0 ? (
+        <CollectionSelectorItemList
+          collections={props.unselectedCollections}
+          selectedCollections={props.selectedCollections}
+          onChange={props.onChange}
+        />
+      ) : (
+        !hasSelectedCollections && (
+          <Alert color="gray" title={props.emptyMessage} />
+        )
+      )}
+    </Stack>
+  );
+}

--- a/src/webapp/features/collections/components/collectionSelectorMyCollections/CollectionSelectorMyCollections.tsx
+++ b/src/webapp/features/collections/components/collectionSelectorMyCollections/CollectionSelectorMyCollections.tsx
@@ -2,7 +2,6 @@ import {
   Alert,
   Button,
   CloseButton,
-  Divider,
   ScrollArea,
   Stack,
   TextInput,
@@ -11,6 +10,7 @@ import {
 } from '@mantine/core';
 import { IoSearch } from 'react-icons/io5';
 import CollectionSelectorItemList from '../collectionSelectorItemList/CollectionSelectorItemList';
+import CollectionSelectorBrowseList from '../collectionSelectorBrowseList/CollectionSelectorBrowseList';
 import { Fragment, useState } from 'react';
 import { FiPlus } from 'react-icons/fi';
 import { useDebouncedValue } from '@mantine/hooks';
@@ -18,6 +18,7 @@ import useCollectionSearch from '../../lib/queries/useCollectionSearch';
 import useMyCollections from '../../lib/queries/useMyCollections';
 import CollectionSelectorError from '../collectionSelector/Error.CollectionSelector';
 import CreateCollectionDrawer from '../createCollectionDrawer/CreateCollectionDrawer';
+import InfiniteScroll from '@/components/contentDisplay/infiniteScroll/InfiniteScroll';
 import { Collection } from '@semble/types';
 
 interface Props {
@@ -26,7 +27,8 @@ interface Props {
 }
 
 export default function CollectionSelectorMyCollections(props: Props) {
-  const { data, error } = useMyCollections();
+  const { data, error, fetchNextPage, hasNextPage, isFetchingNextPage } =
+    useMyCollections();
   const [search, setSearch] = useState('');
   const [debouncedSearch] = useDebouncedValue(search, 200);
   const searchedCollections = useCollectionSearch({ query: debouncedSearch });
@@ -36,8 +38,11 @@ export default function CollectionSelectorMyCollections(props: Props) {
     data?.pages.flatMap((page) => page.collections ?? []).filter((c) => c.id) ??
     [];
 
+  const searchResults =
+    searchedCollections.data?.pages.flatMap((page) => page.collections ?? []) ??
+    [];
+
   const hasCollections = allCollections.length > 0;
-  const hasSelectedCollections = props.selectedCollections.length > 0;
 
   // filter out selected from all to avoid duplication
   const unselectedCollections = allCollections.filter(
@@ -107,52 +112,44 @@ export default function CollectionSelectorMyCollections(props: Props) {
                   )}
 
                   {searchedCollections.data &&
-                    (searchedCollections.data.collections.length === 0 ? (
+                    (searchResults.length === 0 ? (
                       <Alert
                         color="gray"
                         title={`No results found for "${search}"`}
                       />
                     ) : (
-                      <CollectionSelectorItemList
-                        collections={searchedCollections.data.collections}
-                        selectedCollections={props.selectedCollections}
-                        onChange={handleCollectionChange}
-                      />
+                      <InfiniteScroll
+                        dataLength={searchResults.length}
+                        hasMore={!!searchedCollections.hasNextPage}
+                        isInitialLoading={searchedCollections.isPending}
+                        isLoading={searchedCollections.isFetchingNextPage}
+                        loadMore={() => searchedCollections.fetchNextPage()}
+                        hideEndIndicator
+                      >
+                        <CollectionSelectorItemList
+                          collections={searchResults}
+                          selectedCollections={props.selectedCollections}
+                          onChange={handleCollectionChange}
+                        />
+                      </InfiniteScroll>
                     ))}
                 </Stack>
               ) : hasCollections ? (
-                <Stack gap={'xs'}>
-                  {/* selected collections */}
-                  {hasSelectedCollections && (
-                    <Fragment>
-                      <Text fw={600} fz={'sm'} c={'gray'}>
-                        Selected Collections ({props.selectedCollections.length}
-                        )
-                      </Text>
-                      <CollectionSelectorItemList
-                        collections={props.selectedCollections}
-                        selectedCollections={props.selectedCollections}
-                        onChange={handleCollectionChange}
-                      />
-                      {unselectedCollections.length > 0 && (
-                        <Divider variant="dashed" my="xs" />
-                      )}
-                    </Fragment>
-                  )}
-
-                  {/* remaining collections */}
-                  {unselectedCollections.length > 0 ? (
-                    <CollectionSelectorItemList
-                      collections={unselectedCollections}
-                      selectedCollections={props.selectedCollections}
-                      onChange={handleCollectionChange}
-                    />
-                  ) : (
-                    !hasSelectedCollections && (
-                      <Alert color="gray" title="No collections available" />
-                    )
-                  )}
-                </Stack>
+                <InfiniteScroll
+                  dataLength={allCollections.length}
+                  hasMore={!!hasNextPage}
+                  isInitialLoading={false}
+                  isLoading={isFetchingNextPage}
+                  loadMore={() => fetchNextPage()}
+                  hideEndIndicator
+                >
+                  <CollectionSelectorBrowseList
+                    selectedCollections={props.selectedCollections}
+                    unselectedCollections={unselectedCollections}
+                    onChange={handleCollectionChange}
+                    emptyMessage="No collections available"
+                  />
+                </InfiniteScroll>
               ) : (
                 <Stack align="center" gap="xs">
                   <Text fz="lg" fw={600} c="gray">

--- a/src/webapp/features/collections/components/collectionSelectorOpenCollections/CollectionSelectorOpenCollections.tsx
+++ b/src/webapp/features/collections/components/collectionSelectorOpenCollections/CollectionSelectorOpenCollections.tsx
@@ -2,7 +2,6 @@ import {
   Alert,
   Button,
   CloseButton,
-  Divider,
   ScrollArea,
   Stack,
   TextInput,
@@ -11,12 +10,14 @@ import {
 } from '@mantine/core';
 import { IoSearch } from 'react-icons/io5';
 import CollectionSelectorItemList from '../collectionSelectorItemList/CollectionSelectorItemList';
+import CollectionSelectorBrowseList from '../collectionSelectorBrowseList/CollectionSelectorBrowseList';
 import { Fragment, useState } from 'react';
 import { FiPlus } from 'react-icons/fi';
 import { useDebouncedValue } from '@mantine/hooks';
 import CollectionSelectorError from '../collectionSelector/Error.CollectionSelector';
 import CreateCollectionDrawer from '../createCollectionDrawer/CreateCollectionDrawer';
 import useSearchCollections from '../../lib/queries/useSearchCollections';
+import InfiniteScroll from '@/components/contentDisplay/infiniteScroll/InfiniteScroll';
 import { Collection, CollectionAccessType } from '@semble/types';
 import useOpenCollectionsWithContributor from '../../lib/queries/useOpenCollectionsWithContributor';
 import { useAuth } from '@/hooks/useAuth';
@@ -65,8 +66,14 @@ export default function CollectionSelectorOpenCollections(props: Props) {
       ? userCollections
       : searchResults;
 
+  // Query backing the currently displayed list, used for pagination
+  const listQuery = search
+    ? searchedCollections
+    : userCollections.length > 0
+      ? userContributedCollections
+      : searchedCollections;
+
   const hasCollections = allCollections.length > 0;
-  const hasSelectedCollections = props.selectedCollections.length > 0;
 
   // filter out selected from all to avoid duplication
   const unselectedCollections = allCollections.filter(
@@ -85,9 +92,10 @@ export default function CollectionSelectorOpenCollections(props: Props) {
     }
   };
 
-  // Determine which query is active
-  const activeQuery = search ? searchedCollections : userContributedCollections;
-  const isLoading = activeQuery.isPending;
+  // Loading state of the query backing the displayed list. Covers the
+  // fallback case where contributed collections are empty and global open
+  // collections are still being fetched.
+  const isLoading = listQuery.isPending;
 
   if (searchedCollections.error || userContributedCollections.error) {
     return <CollectionSelectorError />;
@@ -146,11 +154,20 @@ export default function CollectionSelectorOpenCollections(props: Props) {
                     />
                   ) : (
                     !isLoading && (
-                      <CollectionSelectorItemList
-                        collections={allCollections}
-                        selectedCollections={props.selectedCollections}
-                        onChange={handleCollectionChange}
-                      />
+                      <InfiniteScroll
+                        dataLength={allCollections.length}
+                        hasMore={!!listQuery.hasNextPage}
+                        isInitialLoading={isLoading}
+                        isLoading={listQuery.isFetchingNextPage}
+                        loadMore={() => listQuery.fetchNextPage()}
+                        hideEndIndicator
+                      >
+                        <CollectionSelectorItemList
+                          collections={allCollections}
+                          selectedCollections={props.selectedCollections}
+                          onChange={handleCollectionChange}
+                        />
+                      </InfiniteScroll>
                     )
                   )}
                 </Stack>
@@ -159,41 +176,21 @@ export default function CollectionSelectorOpenCollections(props: Props) {
                   <Loader color="gray" />
                 </Stack>
               ) : hasCollections ? (
-                <Stack gap={'xs'}>
-                  {/* selected collections */}
-                  {hasSelectedCollections && (
-                    <Fragment>
-                      <Text fw={600} fz={'sm'} c={'gray'}>
-                        Selected Collections ({props.selectedCollections.length}
-                        )
-                      </Text>
-                      <CollectionSelectorItemList
-                        collections={props.selectedCollections}
-                        selectedCollections={props.selectedCollections}
-                        onChange={handleCollectionChange}
-                      />
-                      {unselectedCollections.length > 0 && (
-                        <Divider variant="dashed" my="xs" />
-                      )}
-                    </Fragment>
-                  )}
-
-                  {/* remaining collections */}
-                  {unselectedCollections.length > 0 ? (
-                    <CollectionSelectorItemList
-                      collections={unselectedCollections}
-                      selectedCollections={props.selectedCollections}
-                      onChange={handleCollectionChange}
-                    />
-                  ) : (
-                    !hasSelectedCollections && (
-                      <Alert
-                        color="gray"
-                        title="No open collections available"
-                      />
-                    )
-                  )}
-                </Stack>
+                <InfiniteScroll
+                  dataLength={allCollections.length}
+                  hasMore={!!listQuery.hasNextPage}
+                  isInitialLoading={false}
+                  isLoading={listQuery.isFetchingNextPage}
+                  loadMore={() => listQuery.fetchNextPage()}
+                  hideEndIndicator
+                >
+                  <CollectionSelectorBrowseList
+                    selectedCollections={props.selectedCollections}
+                    unselectedCollections={unselectedCollections}
+                    onChange={handleCollectionChange}
+                    emptyMessage="No open collections available"
+                  />
+                </InfiniteScroll>
               ) : (
                 <Stack align="center" gap="xs">
                   <Text fz="lg" fw={600} c="gray">

--- a/src/webapp/features/collections/components/gemsOfYearBanner/GemsOfYearBanner.tsx
+++ b/src/webapp/features/collections/components/gemsOfYearBanner/GemsOfYearBanner.tsx
@@ -14,7 +14,7 @@ export default function GemsOfYearBanner() {
   const hasGemsCollection =
     !isLoadingSearchResults &&
     searchResults &&
-    searchResults.collections.length > 0;
+    searchResults.pages.some((page) => (page.collections ?? []).length > 0);
 
   return (
     <>

--- a/src/webapp/features/collections/lib/queries/useCollectionSearch.tsx
+++ b/src/webapp/features/collections/lib/queries/useCollectionSearch.tsx
@@ -1,4 +1,4 @@
-import { useQuery } from '@tanstack/react-query';
+import { useInfiniteQuery } from '@tanstack/react-query';
 import { getMyCollections } from '../dal';
 import { collectionKeys } from '../collectionKeys';
 import { CollectionSortField } from '@semble/types';
@@ -12,15 +12,23 @@ interface Props {
 }
 
 export default function useCollectionSearch(props: Props) {
-  // TODO: replace with infinite suspense query
-  const collections = useQuery({
-    queryKey: collectionKeys.search(props.query),
-    queryFn: () =>
+  const limit = props.params?.limit ?? 10;
+
+  const collections = useInfiniteQuery({
+    queryKey: collectionKeys.search(props.query, limit),
+    initialPageParam: 1,
+    queryFn: ({ pageParam }) =>
       getMyCollections({
-        limit: props.params?.limit ?? 10,
+        limit,
+        page: pageParam,
         ...getCollectionsSortParams(CollectionSortField.UPDATED_AT),
         searchText: props.query || undefined,
       }),
+    getNextPageParam: (lastPage) => {
+      return lastPage.pagination.hasMore
+        ? lastPage.pagination.currentPage + 1
+        : undefined;
+    },
     enabled: !!props.query,
   });
 


### PR DESCRIPTION
Search results and collection lists in the add-card modal were silently truncated to the first page with no way to load more. There was no "load more" and no indication anything was cut off. Users with many collections couldn't find existing ones, and the short list / false "No results found" could mislead them into creating duplicates.