### PR TITLE
fix: move delete card button into save/cancel row of add modal

### DIFF
--- a/src/webapp/features/cards/components/addCardActions/AddCardActions.tsx
+++ b/src/webapp/features/cards/components/addCardActions/AddCardActions.tsx
@@ -14,11 +14,10 @@ import {
   Textarea,
   VisuallyHidden,
 } from '@mantine/core';
-import { BsExclamation, BsTrash2Fill } from 'react-icons/bs';
+import { BsExclamation } from 'react-icons/bs';
 import { MdOutlineStickyNote2 } from 'react-icons/md';
 
 interface Props {
-  cardId?: string;
   note?: string;
   noteId?: string;
   onUpdateNote: Dispatch<SetStateAction<string | undefined>>;
@@ -27,13 +26,11 @@ interface Props {
 
 export default function AddCardActions(props: Props) {
   const [showDeleteWarning, setShowDeleteWarning] = useState(false);
-  const [showDeleteCardWarning, setShowDeleteCardWarning] = useState(false);
   const [noteMode, setNoteMode] = useState(false);
   const [note, setNote] = useState(props.note);
   const MAX_NOTE_LENGTH = 500;
 
   const removeNote = useRemoveCardFromLibrary();
-  const removeCard = useRemoveCardFromLibrary();
 
   const handleDeleteNote = () => {
     if (!props.noteId) return;
@@ -42,26 +39,6 @@ export default function AddCardActions(props: Props) {
       onError: () => {
         notifications.show({
           message: 'Could not delete note',
-          color: 'red',
-          autoClose: 5000,
-          withCloseButton: true,
-          position: 'top-center',
-          icon: <BsExclamation />,
-        });
-      },
-      onSettled: () => {
-        props.onClose();
-      },
-    });
-  };
-
-  const handleDeleteCard = () => {
-    if (!props.cardId) return;
-
-    removeCard.mutate(props.cardId, {
-      onError: () => {
-        notifications.show({
-          message: 'Could not delete card',
           color: 'red',
           autoClose: 5000,
           withCloseButton: true,
@@ -159,69 +136,31 @@ export default function AddCardActions(props: Props) {
             </Button>
           </Group>
         </Group>
-      ) : showDeleteCardWarning ? (
-        <Group justify="space-between" gap={'xs'}>
-          <Text>Delete card?</Text>
-          <Group gap={'xs'}>
-            <Button
-              color="red"
-              size="xs"
-              onClick={handleDeleteCard}
-              loading={removeCard.isPending}
-            >
-              Delete
-            </Button>
-            <Button
-              variant="light"
-              color="gray"
-              size="xs"
-              onClick={() => setShowDeleteCardWarning(false)}
-            >
-              Cancel
-            </Button>
-          </Group>
-        </Group>
       ) : (
-        <Group gap={'xs'} justify="space-between">
-          <Group gap={'xs'}>
-            <Button
-              variant="light"
-              size="xs"
-              color="gray"
-              leftSection={<MdOutlineStickyNote2 />}
-              onClick={(e) => {
-                e.stopPropagation();
-                setNoteMode(true);
-              }}
-            >
-              {note ? 'Edit note' : 'Add note'}
-            </Button>
-            {props.noteId && (
-              <Button
-                variant="light"
-                color="red"
-                size="xs"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  setShowDeleteWarning(true);
-                }}
-              >
-                Delete note
-              </Button>
-            )}
-          </Group>
-          {props.cardId && (
+        <Group gap={'xs'}>
+          <Button
+            variant="light"
+            size="xs"
+            color="gray"
+            leftSection={<MdOutlineStickyNote2 />}
+            onClick={(e) => {
+              e.stopPropagation();
+              setNoteMode(true);
+            }}
+          >
+            {note ? 'Edit note' : 'Add note'}
+          </Button>
+          {props.noteId && (
             <Button
               variant="light"
               color="red"
               size="xs"
-              leftSection={<BsTrash2Fill />}
               onClick={(e) => {
                 e.stopPropagation();
-                setShowDeleteCardWarning(true);
+                setShowDeleteWarning(true);
               }}
             >
-              Delete card
+              Delete note
             </Button>
           )}
         </Group>

--- a/src/webapp/features/cards/components/addCardToModal/AddCardToModalContent.tsx
+++ b/src/webapp/features/cards/components/addCardToModal/AddCardToModalContent.tsx
@@ -6,6 +6,9 @@ import { useState, useEffect } from 'react';
 import CollectionSelector from '@/features/collections/components/collectionSelector/CollectionSelector';
 import useGetCardFromMyLibrary from '@/features/cards/lib/queries/useGetCardFromMyLibrary';
 import AddCardActions from '../addCardActions/AddCardActions';
+import useRemoveCardFromLibrary from '@/features/cards/lib/mutations/useRemoveCardFromLibrary';
+import { notifications } from '@mantine/notifications';
+import { BsExclamation } from 'react-icons/bs';
 
 interface Props {
   onClose: () => void;
@@ -48,6 +51,29 @@ export default function AddCardToModalContent(props: Props) {
   useEffect(() => {
     setSelectedCollections(cardStatus.data.collections ?? []);
   }, [cardStatus.data.collections]);
+
+  const removeCard = useRemoveCardFromLibrary();
+
+  const handleDeleteCard = () => {
+    const cardId = cardStatus.data.card?.id;
+    if (!cardId) return;
+
+    removeCard.mutate(cardId, {
+      onError: () => {
+        notifications.show({
+          message: 'Could not delete card',
+          color: 'red',
+          autoClose: 5000,
+          withCloseButton: true,
+          position: 'top-center',
+          icon: <BsExclamation />,
+        });
+      },
+      onSettled: () => {
+        props.onClose();
+      },
+    });
+  };
 
   const handleUpdateCard = (e: React.FormEvent) => {
     e.preventDefault();
@@ -117,7 +143,6 @@ export default function AddCardToModalContent(props: Props) {
   return (
     <Stack>
       <AddCardActions
-        cardId={cardStatus.data.card?.id}
         note={isMyCard ? note : cardStatus.data.card?.note?.text}
         noteId={cardStatus.data.card?.note?.id}
         onUpdateNote={setNote}
@@ -133,6 +158,8 @@ export default function AddCardToModalContent(props: Props) {
         }}
         onSave={handleUpdateCard}
         isSaving={props.isSaving}
+        onDeleteCard={cardStatus.data.card ? handleDeleteCard : undefined}
+        isDeletingCard={removeCard.isPending}
         selectedCollections={selectedCollections}
         onSelectedCollectionsChange={setSelectedCollections}
       />

--- a/src/webapp/features/collections/components/collectionSelector/CollectionSelector.tsx
+++ b/src/webapp/features/collections/components/collectionSelector/CollectionSelector.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Suspense } from 'react';
+import { Suspense, useState } from 'react';
 import {
   Stack,
   Button,
@@ -11,12 +11,15 @@ import {
   Scroller,
   Loader,
   Text,
+  Tooltip,
+  ActionIcon,
 } from '@mantine/core';
 import CollectionSelectorMyCollections from '../collectionSelectorMyCollections/CollectionSelectorMyCollections';
 import CollectionSelectorOpenCollections from '../collectionSelectorOpenCollections/CollectionSelectorOpenCollections';
 import classes from './TabItem.module.css';
 import { Collection } from '@semble/types';
 import { FaSeedling } from 'react-icons/fa6';
+import { BsTrash2Fill } from 'react-icons/bs';
 
 interface Props {
   isOpen: boolean;
@@ -24,11 +27,15 @@ interface Props {
   onCancel: () => void;
   onSave: (e: React.FormEvent) => void;
   isSaving?: boolean;
+  onDeleteCard?: () => void;
+  isDeletingCard?: boolean;
   selectedCollections: Collection[];
   onSelectedCollectionsChange: (collectionIds: Collection[]) => void;
 }
 
 export default function CollectionSelector(props: Props) {
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+
   return (
     <Stack gap={'xl'}>
       <FocusTrap.InitialFocus />
@@ -89,26 +96,69 @@ export default function CollectionSelector(props: Props) {
       </Tabs>
 
       {/* Action Buttons */}
-      <Group justify="space-between" gap="xs" grow>
-        <Button
-          variant="light"
-          color="gray"
-          size="md"
-          onClick={() => props.onCancel()}
-        >
-          Cancel
-        </Button>
+      {showDeleteConfirm ? (
+        <Group justify="space-between" gap="xs" wrap="nowrap">
+          <Text fw={500} c="red">
+            Delete card?
+          </Text>
+          <Group gap="xs" wrap="nowrap">
+            <Button
+              variant="light"
+              color="gray"
+              size="md"
+              disabled={props.isDeletingCard}
+              onClick={() => setShowDeleteConfirm(false)}
+            >
+              Cancel
+            </Button>
+            <Button
+              color="red"
+              size="md"
+              onClick={props.onDeleteCard}
+              loading={props.isDeletingCard}
+            >
+              Delete
+            </Button>
+          </Group>
+        </Group>
+      ) : (
+        <Group gap="xs" wrap="nowrap">
+          {props.onDeleteCard && (
+            <Tooltip label="Delete card">
+              <ActionIcon
+                size={42}
+                radius="xl"
+                variant="light"
+                color="red"
+                aria-label="Delete card"
+                disabled={props.isSaving}
+                onClick={() => setShowDeleteConfirm(true)}
+              >
+                <BsTrash2Fill size={16} />
+              </ActionIcon>
+            </Tooltip>
+          )}
+          <Button
+            variant="light"
+            color="gray"
+            size="md"
+            onClick={() => props.onCancel()}
+          >
+            Cancel
+          </Button>
 
-        <Button
-          size="md"
-          loading={props.isSaving}
-          onClick={(e) => {
-            props.onSave(e);
-          }}
-        >
-          Save
-        </Button>
-      </Group>
+          <Button
+            size="md"
+            style={{ flex: 1 }}
+            loading={props.isSaving}
+            onClick={(e) => {
+              props.onSave(e);
+            }}
+          >
+            Save
+          </Button>
+        </Group>
+      )}
     </Stack>
   );
 }

--- a/src/webapp/features/semble/components/sembleActions/SembleActions.tsx
+++ b/src/webapp/features/semble/components/sembleActions/SembleActions.tsx
@@ -1,9 +1,8 @@
 'use client';
 
 import AddCardToModal from '@/features/cards/components/addCardToModal/AddCardToModal';
-import RemoveCardFromLibraryModal from '@/features/cards/components/removeCardFromLibraryModal/RemoveCardFromLibraryModal';
 import useGetCardFromMyLibrary from '@/features/cards/lib/queries/useGetCardFromMyLibrary';
-import { ActionIcon, Button, Group } from '@mantine/core';
+import { Button, Group } from '@mantine/core';
 import { Fragment, useState } from 'react';
 import { FiPlus } from 'react-icons/fi';
 import { IoMdCheckmark } from 'react-icons/io';
@@ -13,7 +12,6 @@ import { CardSaveSource } from '@/features/analytics/types';
 import { usePathname } from 'next/navigation';
 import { TbPlugConnected } from 'react-icons/tb';
 import AddConnectionModal from '@/features/connections/components/addConnectionModal/AddConnectionModal';
-import { BsTrash2Fill } from 'react-icons/bs';
 
 interface Props {
   url: string;
@@ -26,7 +24,6 @@ export default function SembleActions(props: Props) {
   const isInYourLibrary = cardStatus.data.card?.urlInLibrary;
   const [showAddToModal, setShowAddToModal] = useState(false);
   const [showAddConnectionModal, setShowAddConnectionModal] = useState(false);
-  const [showRemoveModal, setShowRemoveModal] = useState(false);
 
   const { data } = useSembleLibraries({ url: props.url });
   const allLibraries =
@@ -67,17 +64,6 @@ export default function SembleActions(props: Props) {
         >
           {isInYourLibrary ? 'Update' : 'Add'}
         </Button>
-        {isInYourLibrary && (
-          <ActionIcon
-            variant="light"
-            color="red"
-            size={36}
-            radius={'xl'}
-            onClick={() => setShowRemoveModal(true)}
-          >
-            <BsTrash2Fill />
-          </ActionIcon>
-        )}
       </Group>
 
       <AddConnectionModal
@@ -101,13 +87,6 @@ export default function SembleActions(props: Props) {
           pagePath: pathname,
         }}
       />
-      {isInYourLibrary && cardStatus.data.card?.id && (
-        <RemoveCardFromLibraryModal
-          isOpen={showRemoveModal}
-          onClose={() => setShowRemoveModal(false)}
-          cardId={cardStatus.data.card.id}
-        />
-      )}
     </Fragment>
   );
 }


### PR DESCRIPTION
This replaces the "Delete card" text button in the add-to modal's actions row with an icon-only trash button next to Cancel, matching the extension's layout: delete icon (fixed), Cancel (intrinsic width), Save (fills row). 

Clicking the icon shows an inline "Delete card?" confirmation. 

Also removes the now redundant standalone delete icon from SembleActions, since deletion is available inside the add-to modal.