### PR TITLE
feat: add scroll fade and tighter spacing to collection selector

### DIFF
--- a/src/webapp/features/collections/components/collectionSelector/CollectionListScrollArea.tsx
+++ b/src/webapp/features/collections/components/collectionSelector/CollectionListScrollArea.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import { ReactNode } from 'react';
+import { ScrollArea } from '@mantine/core';
+import { useScrollFade } from '@/hooks/useScrollFade';
+
+// Total height of a selector tab panel (search input + collection list).
+// Fixed so the modal keeps the same height across loading, loaded, and
+// few-collections states; the scroll area flexes to fill whatever the
+// search row doesn't use.
+export const COLLECTION_PANEL_HEIGHT = 284;
+
+interface Props {
+  children: ReactNode;
+}
+
+// Scroll container for the selector tabs' collection lists. Fills the
+// remaining panel height and fades the top/bottom edge when there is more
+// content to scroll to.
+export default function CollectionListScrollArea(props: Props) {
+  const { setViewport, maskImage, updateFade } = useScrollFade();
+
+  return (
+    <ScrollArea
+      type="auto"
+      style={{ flex: 1, minHeight: 0 }}
+      viewportRef={setViewport}
+      onScrollPositionChange={updateFade}
+      styles={{
+        viewport: maskImage
+          ? { maskImage, WebkitMaskImage: maskImage }
+          : undefined,
+      }}
+    >
+      {props.children}
+    </ScrollArea>
+  );
+}

--- a/src/webapp/features/collections/components/collectionSelector/CollectionSelector.tsx
+++ b/src/webapp/features/collections/components/collectionSelector/CollectionSelector.tsx
@@ -8,7 +8,6 @@ import {
   FocusTrap,
   Tabs,
   ThemeIcon,
-  Scroller,
   Loader,
   Text,
   Tooltip,
@@ -20,6 +19,7 @@ import classes from './TabItem.module.css';
 import { Collection } from '@semble/types';
 import { FaSeedling } from 'react-icons/fa6';
 import { BsTrash2Fill } from 'react-icons/bs';
+import { COLLECTION_PANEL_HEIGHT } from './CollectionListScrollArea';
 
 interface Props {
   isOpen: boolean;
@@ -41,33 +41,35 @@ export default function CollectionSelector(props: Props) {
       <FocusTrap.InitialFocus />
       <Tabs defaultValue={'myCollections'} keepMounted={false}>
         <Tabs.List grow mb={'xs'} style={{ flexWrap: 'nowrap' }}>
-          <Scroller>
-            <Tabs.Tab classNames={classes} value="myCollections">
-              My Collections
-            </Tabs.Tab>
-            <Tabs.Tab
-              classNames={classes}
-              leftSection={
-                <ThemeIcon
-                  variant="light"
-                  radius={'xl'}
-                  size={'xs'}
-                  color="green"
-                >
-                  <FaSeedling size={8} />
-                </ThemeIcon>
-              }
-              value="openCollections"
-            >
-              Open Collections
-            </Tabs.Tab>
-          </Scroller>
+          <Tabs.Tab classNames={classes} value="myCollections">
+            My Collections
+          </Tabs.Tab>
+          <Tabs.Tab
+            classNames={classes}
+            leftSection={
+              <ThemeIcon
+                variant="light"
+                radius={'xl'}
+                size={'xs'}
+                color="green"
+              >
+                <FaSeedling size={8} />
+              </ThemeIcon>
+            }
+            value="openCollections"
+          >
+            Open Collections
+          </Tabs.Tab>
         </Tabs.List>
 
         <Tabs.Panel value="myCollections">
           <Suspense
             fallback={
-              <Stack align="center" gap="xs">
+              <Stack
+                align="center"
+                justify="center"
+                h={COLLECTION_PANEL_HEIGHT}
+              >
                 <Loader color="gray" />
               </Stack>
             }
@@ -82,7 +84,11 @@ export default function CollectionSelector(props: Props) {
         <Tabs.Panel value="openCollections">
           <Suspense
             fallback={
-              <Stack align="center" gap="xs">
+              <Stack
+                align="center"
+                justify="center"
+                h={COLLECTION_PANEL_HEIGHT}
+              >
                 <Loader color="gray" />
               </Stack>
             }

--- a/src/webapp/features/collections/components/collectionSelector/Skeleton.CollectionSelector.tsx
+++ b/src/webapp/features/collections/components/collectionSelector/Skeleton.CollectionSelector.tsx
@@ -1,13 +1,17 @@
 import { Skeleton, Stack } from '@mantine/core';
+import { COLLECTION_PANEL_HEIGHT } from './CollectionListScrollArea';
 
+// Mirrors the loaded layout of AddCardToModalContent (note actions, tabs,
+// tab panel, action buttons) so the modal keeps its height while loading.
 export default function CollectionSelectorSkeleton() {
   return (
-    <Stack gap={'xs'}>
-      <Skeleton w={'100%'} h={50} />
-      <Skeleton w={'100%'} h={50} />
-      <Skeleton w={'100%'} h={50} />
-      <Skeleton w={'100%'} h={50} />
-      <Skeleton w={'100%'} h={50} />
+    <Stack gap={'md'}>
+      <Skeleton w={140} h={30} radius={'xl'} />
+      <Stack gap={'xs'}>
+        <Skeleton w={'100%'} h={40} />
+        <Skeleton w={'100%'} h={COLLECTION_PANEL_HEIGHT} />
+      </Stack>
+      <Skeleton w={'100%'} h={42} mt={'md'} radius={'xl'} />
     </Stack>
   );
 }

--- a/src/webapp/features/collections/components/collectionSelectorBrowseList/CollectionSelectorBrowseList.tsx
+++ b/src/webapp/features/collections/components/collectionSelectorBrowseList/CollectionSelectorBrowseList.tsx
@@ -14,7 +14,7 @@ export default function CollectionSelectorBrowseList(props: Props) {
   const hasSelectedCollections = props.selectedCollections.length > 0;
 
   return (
-    <Stack gap={'xs'}>
+    <Stack gap={'xxs'}>
       {/* selected collections */}
       {hasSelectedCollections && (
         <Fragment>

--- a/src/webapp/features/collections/components/collectionSelectorItemList/CollectionSelectorItemList.tsx
+++ b/src/webapp/features/collections/components/collectionSelectorItemList/CollectionSelectorItemList.tsx
@@ -11,7 +11,7 @@ interface Props {
 
 export default function CollectionSelectorItemList(props: Props) {
   return (
-    <Stack gap={'xs'}>
+    <Stack gap={'xxs'}>
       {props.collections.map((c) => (
         <CollectionSelectorItem
           key={c.id}

--- a/src/webapp/features/collections/components/collectionSelectorMyCollections/CollectionSelectorMyCollections.tsx
+++ b/src/webapp/features/collections/components/collectionSelectorMyCollections/CollectionSelectorMyCollections.tsx
@@ -2,7 +2,6 @@ import {
   Alert,
   Button,
   CloseButton,
-  ScrollArea,
   Stack,
   TextInput,
   Text,
@@ -20,6 +19,9 @@ import CollectionSelectorError from '../collectionSelector/Error.CollectionSelec
 import CreateCollectionDrawer from '../createCollectionDrawer/CreateCollectionDrawer';
 import InfiniteScroll from '@/components/contentDisplay/infiniteScroll/InfiniteScroll';
 import { Collection } from '@semble/types';
+import CollectionListScrollArea, {
+  COLLECTION_PANEL_HEIGHT,
+} from '../collectionSelector/CollectionListScrollArea';
 
 interface Props {
   selectedCollections: Collection[];
@@ -68,7 +70,7 @@ export default function CollectionSelectorMyCollections(props: Props) {
   return (
     <Fragment>
       <Stack gap="xl">
-        <Stack gap={'sm'}>
+        <Stack gap={'sm'} h={COLLECTION_PANEL_HEIGHT}>
           <TextInput
             placeholder="Search for collections"
             value={search}
@@ -86,8 +88,8 @@ export default function CollectionSelectorMyCollections(props: Props) {
             }
           />
 
-          <ScrollArea.Autosize mah={195} type="auto">
-            <Stack gap="xs">
+          <CollectionListScrollArea>
+            <Stack gap="xxs">
               <Button
                 variant="light"
                 color="grape"
@@ -101,7 +103,7 @@ export default function CollectionSelectorMyCollections(props: Props) {
               </Button>
 
               {search ? (
-                <Stack gap={'xs'}>
+                <Stack gap={'xxs'}>
                   {searchedCollections.isPending && (
                     <Stack align="center">
                       <Text fw={500} c="gray">
@@ -158,7 +160,7 @@ export default function CollectionSelectorMyCollections(props: Props) {
                 </Stack>
               )}
             </Stack>
-          </ScrollArea.Autosize>
+          </CollectionListScrollArea>
         </Stack>
       </Stack>
 

--- a/src/webapp/features/collections/components/collectionSelectorOpenCollections/CollectionSelectorOpenCollections.tsx
+++ b/src/webapp/features/collections/components/collectionSelectorOpenCollections/CollectionSelectorOpenCollections.tsx
@@ -2,7 +2,6 @@ import {
   Alert,
   Button,
   CloseButton,
-  ScrollArea,
   Stack,
   TextInput,
   Text,
@@ -21,6 +20,9 @@ import InfiniteScroll from '@/components/contentDisplay/infiniteScroll/InfiniteS
 import { Collection, CollectionAccessType } from '@semble/types';
 import useOpenCollectionsWithContributor from '../../lib/queries/useOpenCollectionsWithContributor';
 import { useAuth } from '@/hooks/useAuth';
+import CollectionListScrollArea, {
+  COLLECTION_PANEL_HEIGHT,
+} from '../collectionSelector/CollectionListScrollArea';
 
 interface Props {
   selectedCollections: Collection[];
@@ -104,7 +106,7 @@ export default function CollectionSelectorOpenCollections(props: Props) {
   return (
     <Fragment>
       <Stack gap="xl">
-        <Stack gap={'sm'}>
+        <Stack gap={'sm'} h={COLLECTION_PANEL_HEIGHT}>
           <TextInput
             placeholder="Search for open collections"
             value={search}
@@ -122,8 +124,8 @@ export default function CollectionSelectorOpenCollections(props: Props) {
             }
           />
 
-          <ScrollArea.Autosize mah={195} type="auto">
-            <Stack gap="xs">
+          <CollectionListScrollArea>
+            <Stack gap="xxs">
               <Button
                 variant="light"
                 color="grape"
@@ -137,7 +139,7 @@ export default function CollectionSelectorOpenCollections(props: Props) {
               </Button>
 
               {search ? (
-                <Stack gap={'xs'}>
+                <Stack gap={'xxs'}>
                   {isLoading && (
                     <Stack align="center">
                       <Text fw={500} c="gray">
@@ -199,7 +201,7 @@ export default function CollectionSelectorOpenCollections(props: Props) {
                 </Stack>
               )}
             </Stack>
-          </ScrollArea.Autosize>
+          </CollectionListScrollArea>
         </Stack>
       </Stack>
 

--- a/src/webapp/hooks/useScrollFade.ts
+++ b/src/webapp/hooks/useScrollFade.ts
@@ -1,0 +1,63 @@
+'use client';
+
+import { useCallback, useRef, useState } from 'react';
+
+/**
+ * Fades whichever edge of a ScrollArea has more content to scroll to. Wire the
+ * returned `setViewport` to `ScrollArea`'s `viewportRef`, `updateFade` to its
+ * `onScrollPositionChange`, and apply `maskImage` to the viewport. A
+ * ResizeObserver tracks viewport/content size changes, so consumers don't
+ * need an effect to refresh the fade when content changes.
+ */
+export function useScrollFade() {
+  const viewportRef = useRef<HTMLDivElement | null>(null);
+  const [fadeTop, setFadeTop] = useState(false);
+  const [fadeBottom, setFadeBottom] = useState(false);
+
+  const updateFade = useCallback(() => {
+    const el = viewportRef.current;
+    if (!el) return;
+    const overflowing = el.scrollHeight > el.clientHeight + 1;
+    const atTop = el.scrollTop <= 1;
+    const atBottom = el.scrollTop + el.clientHeight >= el.scrollHeight - 1;
+    setFadeTop(overflowing && !atTop);
+    setFadeBottom(overflowing && !atBottom);
+  }, []);
+
+  // Callback ref (rather than an effect) so the observer re-attaches whenever
+  // the ScrollArea itself mounts/unmounts, e.g. when conditionally rendered.
+  // The returned cleanup (React 19) tears the observer down on unmount.
+  // Memoized so consumer re-renders don't detach/re-attach the ref (React
+  // re-runs a callback ref whenever its identity changes).
+  const setViewport = useCallback(
+    (el: HTMLDivElement) => {
+      viewportRef.current = el;
+      const observer = new ResizeObserver(updateFade);
+      // The viewport for its own resizes, the content wrapper for growth
+      // (new items, filtering, images loading in). Observing fires an initial
+      // measurement, which replaces the old on-mount effect.
+      observer.observe(el);
+      if (el.firstElementChild) observer.observe(el.firstElementChild);
+      return () => {
+        observer.disconnect();
+        viewportRef.current = null;
+      };
+    },
+    [updateFade],
+  );
+
+  const maskImage = fadeMask(fadeTop, fadeBottom);
+
+  return { setViewport, maskImage, updateFade };
+}
+
+/** Builds a vertical mask that fades the top and/or bottom edges. */
+function fadeMask(top: boolean, bottom: boolean): string | undefined {
+  if (top && bottom) {
+    return 'linear-gradient(to bottom, transparent, #000 38px, #000 calc(100% - 38px), transparent)';
+  }
+  if (top) return 'linear-gradient(to bottom, transparent, #000 38px)';
+  if (bottom)
+    return 'linear-gradient(to bottom, #000 calc(100% - 38px), transparent)';
+  return undefined;
+}


### PR DESCRIPTION
- Fade the top/bottom edges of the collection list when there's more to scroll (new `useScrollFade` hook, ported from the extension)
- Extract shared `CollectionListScrollArea` used by both selector tabs
- Fix the tab panel height so the add-to modal keeps the same height across loading/loaded/few-collections states (skeleton and tab fallbacks mirror the loaded layout)
- Tighten collection row gaps to `xxs`
- Make the two selector tabs grow to fill the modal width