### PR TITLE
Make modal Cancel/action buttons consistent

### DIFF
--- a/src/webapp/features/cards/components/addCardActions/AddCardActions.tsx
+++ b/src/webapp/features/cards/components/addCardActions/AddCardActions.tsx
@@ -92,6 +92,7 @@ export default function AddCardActions(props: Props) {
                 <Button
                   variant="light"
                   color="gray"
+                  size="md"
                   disabled={removeNote.isPending}
                   onClick={() => setShowDeleteWarning(false)}
                 >
@@ -99,6 +100,7 @@ export default function AddCardActions(props: Props) {
                 </Button>
                 <Button
                   color="red"
+                  size="md"
                   onClick={handleDeleteNote}
                   loading={removeNote.isPending}
                 >
@@ -125,6 +127,7 @@ export default function AddCardActions(props: Props) {
               <Button
                 variant="light"
                 color="gray"
+                size="md"
                 onClick={() => {
                   setNoteMode(false);
                   setNote(props.note);
@@ -133,6 +136,7 @@ export default function AddCardActions(props: Props) {
                 Cancel
               </Button>
               <Button
+                size="md"
                 style={{ flex: 1 }}
                 onClick={() => {
                   props.onUpdateNote(note);

--- a/src/webapp/features/cards/components/removeCardFromCollectionModal/RemoveCardFromCollectionModal.tsx
+++ b/src/webapp/features/cards/components/removeCardFromCollectionModal/RemoveCardFromCollectionModal.tsx
@@ -1,4 +1,4 @@
-import { Button, Stack, Modal } from '@mantine/core';
+import { Button, Group, Modal } from '@mantine/core';
 import useRemoveCardFromCollections from '../../lib/mutations/useRemoveCardFromCollections';
 import { notifications } from '@mantine/notifications';
 import { DANGER_OVERLAY_PROPS } from '@/styles/overlays';
@@ -48,19 +48,20 @@ export default function RemoveCardFromCollectionModal(props: Props) {
       centered
       onClick={(e) => e.stopPropagation()}
     >
-      <Stack>
-        <Button variant="subtle" size="md" color="gray" onClick={props.onClose}>
+      <Group gap="xs" wrap="nowrap">
+        <Button variant="light" size="md" color="gray" onClick={props.onClose}>
           Cancel
         </Button>
         <Button
           color="red"
           size="md"
+          style={{ flex: 1 }}
           onClick={handleRemoveCardFromCollection}
           loading={removeCardFromCollection.isPending}
         >
           Remove
         </Button>
-      </Stack>
+      </Group>
     </Modal>
   );
 }

--- a/src/webapp/features/cards/components/removeCardFromLibraryModal/RemoveCardFromLibraryModal.tsx
+++ b/src/webapp/features/cards/components/removeCardFromLibraryModal/RemoveCardFromLibraryModal.tsx
@@ -1,4 +1,4 @@
-import { Button, Stack, Modal } from '@mantine/core';
+import { Button, Group, Modal } from '@mantine/core';
 import useRemoveCardFromLibrary from '../../lib/mutations/useRemoveCardFromLibrary';
 import { notifications } from '@mantine/notifications';
 import { DANGER_OVERLAY_PROPS } from '@/styles/overlays';
@@ -44,19 +44,20 @@ export default function RemoveCardFromLibraryModal(props: Props) {
       centered
       onClick={(e) => e.stopPropagation()}
     >
-      <Stack>
-        <Button variant="subtle" size="md" color="gray" onClick={props.onClose}>
+      <Group gap="xs" wrap="nowrap">
+        <Button variant="light" size="md" color="gray" onClick={props.onClose}>
           Cancel
         </Button>
         <Button
           color="red"
           size="md"
+          style={{ flex: 1 }}
           onClick={handleRemoveCardFromLibrary}
           loading={removeCardFromLibrary.isPending}
         >
           Remove
         </Button>
-      </Stack>
+      </Group>
     </Modal>
   );
 }

--- a/src/webapp/features/cards/components/reportCardModal/ReportCardModal.tsx
+++ b/src/webapp/features/cards/components/reportCardModal/ReportCardModal.tsx
@@ -167,10 +167,11 @@ export default function ReportCardModal(props: Props) {
             </Text>
           )}
 
-          <Group justify="flex-end" gap="xs">
+          <Group gap="xs" wrap="nowrap">
             <Button
-              variant="subtle"
+              variant="light"
               color="gray"
+              size="md"
               onClick={props.onClose}
               disabled={state.kind === 'submitting'}
             >
@@ -178,6 +179,8 @@ export default function ReportCardModal(props: Props) {
             </Button>
             <Button
               color="red"
+              size="md"
+              style={{ flex: 1 }}
               onClick={handleSubmit}
               loading={state.kind === 'submitting'}
               disabled={!canSubmit}

--- a/src/webapp/features/collections/components/deleteCollectionModal/DeleteCollectionModal.tsx
+++ b/src/webapp/features/collections/components/deleteCollectionModal/DeleteCollectionModal.tsx
@@ -1,4 +1,4 @@
-import { Button, Stack, Modal } from '@mantine/core';
+import { Button, Group, Modal } from '@mantine/core';
 import useDeleteCollection from '../../lib/mutations/useDeleteCollection';
 import { notifications } from '@mantine/notifications';
 import { useRouter } from 'next/navigation';
@@ -49,20 +49,21 @@ export default function DeleteCollectionModal(props: Props) {
       overlayProps={DANGER_OVERLAY_PROPS}
       centered
     >
-      <Stack>
-        <Button variant="subtle" size="md" color="gray" onClick={props.onClose}>
+      <Group gap="xs" wrap="nowrap">
+        <Button variant="light" size="md" color="gray" onClick={props.onClose}>
           Cancel
         </Button>
         <Button
           color="red"
           size="md"
+          style={{ flex: 1 }}
           onClick={handleDeleteCollection}
           loading={deleteCollection.isPending}
           data-autofocus
         >
           Delete
         </Button>
-      </Stack>
+      </Group>
     </Modal>
   );
 }

--- a/src/webapp/features/collections/components/editCollectionModal/EditCollectionModal.tsx
+++ b/src/webapp/features/collections/components/editCollectionModal/EditCollectionModal.tsx
@@ -170,7 +170,7 @@ export default function EditCollectionModal(props: Props) {
               </Stack>
             </Stack>
 
-            <Group justify="space-between" gap={'xs'} grow>
+            <Group gap={'xs'} wrap="nowrap">
               <Button
                 variant="light"
                 size="md"
@@ -182,6 +182,7 @@ export default function EditCollectionModal(props: Props) {
               <Button
                 type="submit"
                 size="md"
+                style={{ flex: 1 }}
                 loading={updateCollection.isPending}
               >
                 Save

--- a/src/webapp/features/connections/components/deleteConnectionModal/DeleteConnectionModal.tsx
+++ b/src/webapp/features/connections/components/deleteConnectionModal/DeleteConnectionModal.tsx
@@ -1,4 +1,4 @@
-import { Button, Stack, Modal } from '@mantine/core';
+import { Button, Group, Modal } from '@mantine/core';
 import { notifications } from '@mantine/notifications';
 import { DANGER_OVERLAY_PROPS } from '@/styles/overlays';
 import useDeleteConnection from '../../lib/mutations/useDeleteConnection';
@@ -55,19 +55,20 @@ export default function DeleteConnectionModal(props: Props) {
       withCloseButton={false}
       centered
     >
-      <Stack>
-        <Button variant="subtle" size="md" color="gray" onClick={props.onClose}>
+      <Group gap="xs" wrap="nowrap">
+        <Button variant="light" size="md" color="gray" onClick={props.onClose}>
           Cancel
         </Button>
         <Button
           size="md"
           color="red"
+          style={{ flex: 1 }}
           onClick={handleDelete}
           loading={deleteConnection.isPending}
         >
           Remove
         </Button>
-      </Stack>
+      </Group>
     </Modal>
   );
 }

--- a/src/webapp/features/connections/components/editConnectionForm/EditConnectionForm.tsx
+++ b/src/webapp/features/connections/components/editConnectionForm/EditConnectionForm.tsx
@@ -418,7 +418,7 @@ export default function EditConnectionForm(props: Props) {
           </VisuallyHidden>
         </Stack>
 
-        <Group justify="space-between" gap={'xs'} grow>
+        <Group gap={'xs'} wrap="nowrap">
           <Button
             variant="light"
             size="md"
@@ -427,7 +427,12 @@ export default function EditConnectionForm(props: Props) {
           >
             Cancel
           </Button>
-          <Button type="submit" size="md" loading={updateConnection.isPending}>
+          <Button
+            type="submit"
+            size="md"
+            style={{ flex: 1 }}
+            loading={updateConnection.isPending}
+          >
             Update
           </Button>
         </Group>

--- a/src/webapp/features/follows/components/subscribeButton/SubscribeModal.tsx
+++ b/src/webapp/features/follows/components/subscribeButton/SubscribeModal.tsx
@@ -25,6 +25,7 @@ export default function SubscribeModal(props: Props) {
       opened={props.opened}
       onClose={props.onClose}
       title="Notification settings"
+      size="sm"
       overlayProps={DEFAULT_OVERLAY_PROPS}
       centered
     >
@@ -68,11 +69,13 @@ function ConfirmForm(props: ConfirmFormProps) {
           : 'Get notified about new cards, connections, and saves to this collection.'}
       </Text>
 
-      <Group gap={'xs'} justify="flex-end">
-        <Button variant="light" color="gray" onClick={props.onCancel}>
+      <Group gap={'xs'} wrap="nowrap">
+        <Button variant="light" color="gray" size="md" onClick={props.onCancel}>
           Cancel
         </Button>
         <Button
+          size="md"
+          style={{ flex: 1 }}
           color={props.isSubscribed ? 'red' : undefined}
           onClick={handleConfirm}
           data-autofocus
@@ -135,11 +138,13 @@ function ScopeForm(props: ScopeFormProps) {
         ))}
       </Stack>
 
-      <Group gap={'xs'} justify="flex-end">
-        <Button variant="light" color="gray" onClick={props.onCancel}>
+      <Group gap={'xs'} wrap="nowrap">
+        <Button variant="light" color="gray" size="md" onClick={props.onCancel}>
           Cancel
         </Button>
         <Button
+          size="md"
+          style={{ flex: 1 }}
           disabled={isDisabled}
           onClick={() => props.onConfirm(selected)}
           data-autofocus

--- a/src/webapp/features/notes/components/noteCardModal/NoteCardModalContent.tsx
+++ b/src/webapp/features/notes/components/noteCardModal/NoteCardModalContent.tsx
@@ -130,7 +130,7 @@ export default function NoteCardModalContent(props: Props) {
           </VisuallyHidden>
         </Stack>
 
-        <Group gap={'xs'} grow>
+        <Group gap={'xs'} wrap="nowrap">
           <Button
             variant="light"
             color="gray"
@@ -142,6 +142,7 @@ export default function NoteCardModalContent(props: Props) {
             Cancel
           </Button>
           <Button
+            style={{ flex: 1 }}
             onClick={handleUpdateNote}
             loading={updateNote.isPending}
             disabled={note?.trimEnd() === ''}

--- a/src/webapp/features/settings/containers/apiKeysContainer/ApiKeysContainer.tsx
+++ b/src/webapp/features/settings/containers/apiKeysContainer/ApiKeysContainer.tsx
@@ -212,17 +212,18 @@ export default function ApiKeysContainer() {
             onKeyDown={(e) => e.key === 'Enter' && handleCreate()}
             data-autofocus
           />
-          <Group justify="end" gap={'xs'}>
+          <Group gap={'xs'} wrap="nowrap">
             <Button
               variant="light"
               color="gray"
-              size="sm"
+              size="md"
               onClick={closeCreate}
             >
               Cancel
             </Button>
             <Button
-              size="sm"
+              size="md"
+              style={{ flex: 1 }}
               onClick={handleCreate}
               disabled={!keyName.trim() || isCreating}
               loading={isCreating}
@@ -251,12 +252,13 @@ export default function ApiKeysContainer() {
             onKeyDown={(e) => e.key === 'Enter' && handleEditConfirm()}
             data-autofocus
           />
-          <Group justify="end" gap={'xs'}>
-            <Button variant="light" color="gray" size="sm" onClick={closeEdit}>
+          <Group gap={'xs'} wrap="nowrap">
+            <Button variant="light" color="gray" size="md" onClick={closeEdit}>
               Cancel
             </Button>
             <Button
-              size="sm"
+              size="md"
+              style={{ flex: 1 }}
               onClick={handleEditConfirm}
               disabled={!editName.trim() || isUpdating}
               loading={isUpdating}
@@ -336,19 +338,27 @@ export default function ApiKeysContainer() {
           <Text fz="sm" fw={500} c="gray">
             This key will stop working immediately and cannot be recovered.
           </Text>
-          <Button variant="subtle" size="md" color="gray" onClick={closeRevoke}>
-            Cancel
-          </Button>
-          <Button
-            color="red"
-            size="md"
-            onClick={handleRevokeConfirm}
-            data-autofocus
-            loading={isRevoking}
-            disabled={isRevoking}
-          >
-            Revoke key
-          </Button>
+          <Group gap="xs" wrap="nowrap">
+            <Button
+              variant="light"
+              size="md"
+              color="gray"
+              onClick={closeRevoke}
+            >
+              Cancel
+            </Button>
+            <Button
+              color="red"
+              size="md"
+              style={{ flex: 1 }}
+              onClick={handleRevokeConfirm}
+              data-autofocus
+              loading={isRevoking}
+              disabled={isRevoking}
+            >
+              Revoke key
+            </Button>
+          </Group>
         </Stack>
       </Modal>
     </Container>


### PR DESCRIPTION
Applies the wider-primary-button style from AddCardToModal to other modals, normalizes button sizes to md, and fixes "cancel" buttons that used the subtle variant instead of light.