### PR TITLE
fix(profile): show full links and full bio on profile header

### DIFF
--- a/src/webapp/__tests__/lib/utils/link.test.ts
+++ b/src/webapp/__tests__/lib/utils/link.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   SupportedPlatform,
   detectUrlPlatform,
+  getDisplayUrl,
   getDomain,
   getUrlFromSlug,
   isCollectionPage,
@@ -29,6 +30,91 @@ describe('getDomain', () => {
 
     // Act
     const result = getDomain(url);
+
+    // Assert
+    expect(result).toBe(url);
+  });
+});
+
+// ─────────────────────────────────────────────
+// getDisplayUrl
+// ─────────────────────────────────────────────
+describe('getDisplayUrl', () => {
+  it('should strip the scheme and the www prefix', () => {
+    // Arrange
+    const url = 'https://www.example.com/blog';
+
+    // Act
+    const result = getDisplayUrl(url);
+
+    // Assert
+    expect(result).toBe('example.com/blog');
+  });
+
+  it('should drop the trailing slash of a bare domain', () => {
+    // Arrange
+    const url = 'https://example.com/';
+
+    // Act
+    const result = getDisplayUrl(url);
+
+    // Assert
+    expect(result).toBe('example.com');
+  });
+
+  it('should preserve the path, query and hash when under the budget', () => {
+    // Arrange
+    const url = 'https://example.com/blog?q=1#top';
+
+    // Act
+    const result = getDisplayUrl(url, 30);
+
+    // Assert
+    expect(result).toBe('example.com/blog?q=1#top');
+  });
+
+  it('should cut off the path past the budget while keeping the host whole', () => {
+    // Arrange
+    const url =
+      'https://a-very-long-domain-name.example.com/2026/08/12/us/politics/election';
+
+    // Act
+    const result = getDisplayUrl(url, 30);
+
+    // Assert
+    expect(result).toBe(
+      'a-very-long-domain-name.example.com/2026/08/12/us/politics/electi…',
+    );
+  });
+
+  it('should not truncate when no budget is given', () => {
+    // Arrange
+    const url = 'https://example.com/2026/08/12/us/politics/election?ref=home';
+
+    // Act
+    const result = getDisplayUrl(url);
+
+    // Assert
+    expect(result).toBe('example.com/2026/08/12/us/politics/election?ref=home');
+  });
+
+  it('should return the original string for a non-http(s) scheme', () => {
+    // Arrange
+    const url = 'mailto:someone@example.com';
+
+    // Act
+    const result = getDisplayUrl(url, 30);
+
+    // Assert
+    expect(result).toBe(url);
+  });
+
+  it('should return the original string when the URL is invalid', () => {
+    // Arrange
+    const url = 'not a valid url';
+
+    // Act
+    const result = getDisplayUrl(url, 30);
 
     // Assert
     expect(result).toBe(url);

--- a/src/webapp/components/contentDisplay/richTextRenderer/RichTextRenderer.tsx
+++ b/src/webapp/components/contentDisplay/richTextRenderer/RichTextRenderer.tsx
@@ -3,18 +3,22 @@
 import { RichText } from '@atproto/api';
 
 import { Anchor, AnchorProps, Text, TextProps } from '@mantine/core';
-import { getDomain } from '@/lib/utils/link';
+import { getDisplayUrl } from '@/lib/utils/link';
+
+const MAX_LINK_PATH_LENGTH = 30;
 
 interface Props {
   text: string;
   linkProps?: Partial<AnchorProps>; // for mentions, links, hashtags
   textProps?: Partial<TextProps>; // for plain text
+  linkDisplay?: 'short' | 'full'; // 'short' cuts off long paths (default)
 }
 
 export default function RichTextRenderer({
   text,
   linkProps = {},
   textProps = {},
+  linkDisplay = 'short',
 }: Props) {
   const richText = new RichText({ text });
   richText.detectFacetsWithoutResolution();
@@ -57,7 +61,10 @@ export default function RichTextRenderer({
               onClick={(e) => e.stopPropagation()}
               {...linkProps}
             >
-              {getDomain(segment.link.uri)}
+              {getDisplayUrl(
+                segment.link.uri,
+                linkDisplay === 'full' ? Infinity : MAX_LINK_PATH_LENGTH,
+              )}
             </Anchor>
           );
         }

--- a/src/webapp/features/profile/components/profileHeader/ProfileHeader.tsx
+++ b/src/webapp/features/profile/components/profileHeader/ProfileHeader.tsx
@@ -5,7 +5,6 @@ import {
   Avatar,
   Text,
   Title,
-  Spoiler,
   ActionIcon,
   Tooltip,
   Image,
@@ -128,14 +127,11 @@ export default async function ProfileHeader(props: Props) {
                 </Group>
               </Stack>
               {profile.description && (
-                <Spoiler
-                  showLabel={'Read more'}
-                  hideLabel={'See less'}
-                  maxHeight={75}
-                  maw={700}
-                >
-                  <RichTextRenderer text={profile.description} />
-                </Spoiler>
+                <RichTextRenderer
+                  text={profile.description}
+                  linkDisplay="full"
+                  textProps={{ maw: 700 }}
+                />
               )}
 
               {/* follow stats */}

--- a/src/webapp/lib/utils/link.ts
+++ b/src/webapp/lib/utils/link.ts
@@ -6,6 +6,26 @@ export const getDomain = (url: string) => {
   }
 };
 
+// Formats a URL for display: drops the scheme and any "www.", always keeps the whole
+// domain, and cuts off a long path with a "…". Defaults to showing the full URL.
+export const getDisplayUrl = (url: string, maxPathLength = Infinity) => {
+  try {
+    const urlp = new URL(url);
+    if (urlp.protocol !== 'http:' && urlp.protocol !== 'https:') return url;
+
+    const host = urlp.host.replace(/^www\./, '');
+    const path =
+      (urlp.pathname === '/' ? '' : urlp.pathname) + urlp.search + urlp.hash;
+
+    if (path.length > maxPathLength) {
+      return host + path.slice(0, maxPathLength) + '…';
+    }
+    return host + path;
+  } catch {
+    return url;
+  }
+};
+
 export const getUrlFromSlug = (slug: string[]) => {
   const decoded = slug.map(decodeURIComponent);
   const url = decoded.join('/');


### PR DESCRIPTION
Links in rich text rendered as a bare domain, dropping the path entirely. They now show domain + path with no scheme, cut off with a "…" past a 30-character path budget. The profile bio opts out of the budget and shows links in full, and its "Read more" Spoiler is gone so the whole bio renders.

The host is never truncated, only the path, so a link always shows where it goes. Every other `RichTextRenderer` call site keeps the default short form.