### PR TITLE
Dont store URL metadata in PDS

### DIFF
--- a/src/modules/cards/application/useCases/commands/AddUrlToLibraryUseCase.ts
+++ b/src/modules/cards/application/useCases/commands/AddUrlToLibraryUseCase.ts
@@ -100,25 +100,15 @@ export class AddUrlToLibraryUseCase extends BaseUseCase<
 
       let urlCard = existingUrlCardResult.value;
       if (!urlCard) {
-        // Fetch metadata for URL
-        const metadataResult = await this.metadataService.fetchMetadata(
-          url,
-          true,
-        );
-        let metadata: UrlMetadata;
-        if (metadataResult.isOk()) {
-          metadata = metadataResult.value;
-        } else {
-          metadata = UrlMetadata.create({ url: url.value }).unwrap();
-        }
-
-        // If metadata fetching fails, we continue without metadata
+        // Prime the metadata cache, but don't block on it's results
+        setTimeout(() => this.metadataService.fetchMetadata(url, true), 0);
 
         // Create URL card
+        // Only store user-edited metadata in the PDS
         const urlCardInput: IUrlCardInput = {
           type: CardTypeEnum.URL,
           url: url.value,
-          metadata: metadata,
+          metadata: UrlMetadata.create({ url: url.value }).unwrap(),
           viaCardId: request.viaCardId,
         };
 


### PR DESCRIPTION
This PR stops semble from storing URL metadata in the end-user's PDS. The hope is this significantly speeds up the perceived time it takes to save URLs because the metadata services can be slow and because URL metadata that is not authored by end-users shouldn't be stored in the PDS. 