### PR TITLE
fix(webapp): preserve #fragment in semble page links

### DIFF
--- a/src/webapp/__tests__/lib/utils/link.test.ts
+++ b/src/webapp/__tests__/lib/utils/link.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, it } from 'vitest';
 import {
   SupportedPlatform,
+  buildSembleQuery,
   detectUrlPlatform,
+  encodeUrlParam,
   getDisplayUrl,
   getDomain,
+  getSembleHref,
   getUrlFromSlug,
   isCollectionPage,
   isProfilePage,
@@ -118,6 +121,86 @@ describe('getDisplayUrl', () => {
 
     // Assert
     expect(result).toBe(url);
+  });
+});
+
+// ─────────────────────────────────────────────
+// encodeUrlParam / getSembleHref / buildSembleQuery
+// ─────────────────────────────────────────────
+describe('encodeUrlParam', () => {
+  it('should leave a plain URL readable', () => {
+    expect(encodeUrlParam('https://example.com/path?q=1')).toBe(
+      'https://example.com/path?q=1',
+    );
+  });
+
+  it('should escape the fragment so the browser does not strip it', () => {
+    expect(encodeUrlParam('https://example.com/path#section')).toBe(
+      'https://example.com/path%23section',
+    );
+  });
+
+  it('should escape query separators and existing escapes', () => {
+    expect(encodeUrlParam('https://example.com/a%20b?x=1&y=a+b')).toBe(
+      'https://example.com/a%2520b?x=1%26y=a%2Bb',
+    );
+  });
+
+  it('should round-trip through a single decode', () => {
+    const url = 'https://example.com/a%20b?x=1&y=a+b#frag';
+    expect(new URLSearchParams(`id=${encodeUrlParam(url)}`).get('id')).toBe(
+      url,
+    );
+  });
+});
+
+describe('getSembleHref', () => {
+  it('should build the semble page link with id last', () => {
+    expect(
+      getSembleHref('https://example.com/path#section', {
+        viaCardId: 'card-1',
+        sembleTab: 'notes',
+      }),
+    ).toBe(
+      '/url?viaCardId=card-1&sembleTab=notes&id=https://example.com/path%23section',
+    );
+  });
+
+  it('should omit unset options', () => {
+    expect(getSembleHref('https://example.com')).toBe(
+      '/url?id=https://example.com',
+    );
+  });
+});
+
+describe('buildSembleQuery', () => {
+  it('should re-encode only the id and keep other params raw', () => {
+    const params = new URLSearchParams(
+      '?id=https://example.com/a%23b&sembleTab=notes',
+    );
+    expect(buildSembleQuery(params)).toBe(
+      '?id=https://example.com/a%23b&sembleTab=notes',
+    );
+  });
+
+  it('should omit a param', () => {
+    const params = new URLSearchParams('?viaCardId=x&id=https://example.com');
+    expect(buildSembleQuery(params, { omit: 'viaCardId' })).toBe(
+      '?id=https://example.com',
+    );
+  });
+
+  it('should override an existing param in place and append a missing one', () => {
+    const existing = new URLSearchParams(
+      '?id=https://example.com&sembleTab=notes',
+    );
+    expect(buildSembleQuery(existing, { set: { sembleTab: 'similar' } })).toBe(
+      '?id=https://example.com&sembleTab=similar',
+    );
+    const missing = new URLSearchParams('?id=https://example.com');
+    expect(buildSembleQuery(missing, { set: { sembleTab: 'similar' } })).toBe(
+      '?id=https://example.com&sembleTab=similar',
+    );
   });
 });
 

--- a/src/webapp/app/(dashboard)/url/[...id]/page.tsx
+++ b/src/webapp/app/(dashboard)/url/[...id]/page.tsx
@@ -1,4 +1,4 @@
-import { getUrlFromSlug } from '@/lib/utils/link';
+import { getSembleHref, getUrlFromSlug } from '@/lib/utils/link';
 import { redirect } from 'next/navigation';
 
 interface Props {
@@ -8,5 +8,5 @@ export default async function Page(props: Props) {
   const { id } = await props.params;
   const url = getUrlFromSlug(id);
 
-  redirect(`/url?id=${url}`);
+  redirect(getSembleHref(url));
 }

--- a/src/webapp/app/(dashboard)/url/page.tsx
+++ b/src/webapp/app/(dashboard)/url/page.tsx
@@ -1,5 +1,5 @@
 import type { Metadata } from 'next';
-import { getDomain } from '@/lib/utils/link';
+import { encodeUrlParam, getDomain } from '@/lib/utils/link';
 import { redirect } from 'next/navigation';
 import SemblePageClient from '@/features/semble/containers/sembleContainer/SemblePageClient';
 import SembleContainer from '@/features/semble/containers/sembleContainer/SembleContainer';
@@ -35,7 +35,7 @@ export async function generateMetadata({
     openGraph: {
       images: [
         {
-          url: `${process.env.APP_URL}/api/opengraph/semble?url=${url}`,
+          url: `${process.env.APP_URL}/api/opengraph/semble?url=${encodeUrlParam(url)}`,
           width: 1200,
           height: 630,
           alt: `Semble page for ${domain}`,
@@ -47,9 +47,7 @@ export async function generateMetadata({
 
 export default async function Page(props: Props) {
   const searchParams = await props.searchParams;
-  const url = searchParams.id
-    ? decodeURIComponent(searchParams.id)
-    : searchParams.id;
+  const url = searchParams.id;
   const viaCardId = searchParams.viaCardId;
 
   if (!url) {

--- a/src/webapp/app/(embeds)/embed/url/page.tsx
+++ b/src/webapp/app/(embeds)/embed/url/page.tsx
@@ -12,9 +12,7 @@ interface Props {
 
 export default async function Page(props: Props) {
   const searchParams = await props.searchParams;
-  const url = searchParams.id
-    ? decodeURIComponent(searchParams.id)
-    : searchParams.id;
+  const url = searchParams.id;
   const viaCardId = searchParams.viaCardId;
 
   if (!url) {

--- a/src/webapp/app/(embeds)/page-parts-embed/url/page.tsx
+++ b/src/webapp/app/(embeds)/page-parts-embed/url/page.tsx
@@ -7,9 +7,7 @@ interface Props {
 
 export default async function Page(props: Props) {
   const searchParams = await props.searchParams;
-  const url = searchParams.id
-    ? decodeURIComponent(searchParams.id)
-    : searchParams.id;
+  const url = searchParams.id;
 
   if (!url) {
     redirect('/');

--- a/src/webapp/app/api/opengraph/semble/route.tsx
+++ b/src/webapp/app/api/opengraph/semble/route.tsx
@@ -7,7 +7,7 @@ import {
   normalizeEmbedImageUrl,
 } from '@/features/openGraph/lib/utils/collage';
 import { abbreviateNumber, truncateText } from '@/lib/utils/text';
-import { getDomain, getUrlFromSlug } from '@/lib/utils/link';
+import { getDomain } from '@/lib/utils/link';
 
 // Node runtime is required: fetchImageAsDataUri uses Buffer to base64-encode
 // the pre-fetched thumbnail. Do not switch to 'edge'.
@@ -37,7 +37,7 @@ export async function GET(request: NextRequest) {
   if (url) {
     try {
       const result = await getUrlMetadata({
-        url: getUrlFromSlug([url]),
+        url,
         includeStats: true,
       });
 

--- a/src/webapp/app/bookmarklet/page.tsx
+++ b/src/webapp/app/bookmarklet/page.tsx
@@ -26,7 +26,7 @@ export default function BookmarkletPage() {
 
   const bookmarkletCode = `javascript:(function(){
     const currentUrl = window.location.href;
-    const sembleUrl = '${appUrl}/url?id=' + currentUrl;
+    const sembleUrl = '${appUrl}/url?id=' + encodeURIComponent(currentUrl);
     window.open(sembleUrl, '_blank');
 })();`;
 

--- a/src/webapp/components/landing/activityCard/ActivityCard.tsx
+++ b/src/webapp/components/landing/activityCard/ActivityCard.tsx
@@ -1,7 +1,11 @@
 'use client';
 
 import UrlCardContent from '@/features/cards/components/urlCardContent/UrlCardContent';
-import { isCollectionPage, isProfilePage } from '@/lib/utils/link';
+import {
+  getSembleHref,
+  isCollectionPage,
+  isProfilePage,
+} from '@/lib/utils/link';
 import { Card, Group, Stack, Text } from '@mantine/core';
 import { UrlCard, User } from '@semble/types';
 import { MouseEvent, Suspense } from 'react';
@@ -36,7 +40,7 @@ export default function ActivityCard(props: Props) {
       return;
     }
 
-    router.push(`/url?id=${props.cardContent.url}`);
+    router.push(getSembleHref(props.cardContent.url));
   };
 
   return (

--- a/src/webapp/features/cards/components/cardChip/CardChip.tsx
+++ b/src/webapp/features/cards/components/cardChip/CardChip.tsx
@@ -1,6 +1,6 @@
 import { Image, Group, Text, Tooltip } from '@mantine/core';
 import { truncateText } from '@/lib/utils/text';
-import { getDomain } from '@/lib/utils/link';
+import { getDomain, getSembleHref } from '@/lib/utils/link';
 import { LinkCard } from '@/components/link/MantineLink';
 import styles from './CardChip.module.css';
 
@@ -14,7 +14,7 @@ export default function CardChip(props: Props) {
   return (
     <Tooltip label={getDomain(props.url)}>
       <LinkCard
-        href={`/url?id=${encodeURIComponent(props.url)}`}
+        href={getSembleHref(props.url)}
         radius={'md'}
         px={7}
         py={5}

--- a/src/webapp/features/cards/components/urlCard/UrlCard.tsx
+++ b/src/webapp/features/cards/components/urlCard/UrlCard.tsx
@@ -7,7 +7,11 @@ import UrlCardActions from '../urlCardActions/UrlCardActions';
 import { MouseEvent, Suspense } from 'react';
 import UrlCardContent from '../urlCardContent/UrlCardContent';
 import { useRouter } from 'next/navigation';
-import { isCollectionPage, isProfilePage } from '@/lib/utils/link';
+import {
+  getSembleHref,
+  isCollectionPage,
+  isProfilePage,
+} from '@/lib/utils/link';
 import styles from './UrlCard.module.css';
 import { useSettings } from '@/providers/settings';
 import UrlCardDebugView from '../UrlCardDebugView/UrlCardDebugView';
@@ -55,12 +59,9 @@ export default function UrlCard(props: Props) {
     if (isCollectionPage(props.url) || isProfilePage(props.url)) {
       targetUrl = props.url;
     } else {
-      // Build URL with viaCardId first, then id last (since id contains a URL that might have query params)
-      if (props.viaCardId) {
-        targetUrl = `/url?viaCardId=${props.id}&id=${props.cardContent.url}`;
-      } else {
-        targetUrl = `/url?id=${props.cardContent.url}`;
-      }
+      targetUrl = getSembleHref(props.cardContent.url, {
+        viaCardId: props.viaCardId ? props.id : undefined,
+      });
     }
 
     // Register super properties and capture click event when navigating to semble page

--- a/src/webapp/features/cards/components/urlCardActions/UrlCardActions.tsx
+++ b/src/webapp/features/cards/components/urlCardActions/UrlCardActions.tsx
@@ -34,6 +34,7 @@ import { CardSaveAnalyticsContext } from '@/features/analytics/types';
 import { TbPlugConnected } from 'react-icons/tb';
 import AddConnectionModal from '@/features/connections/components/addConnectionModal/AddConnectionModal';
 import { AiOutlineDisconnect } from 'react-icons/ai';
+import { getSembleHref } from '@/lib/utils/link';
 
 interface Props {
   id: string;
@@ -236,7 +237,7 @@ export default function UrlCardActions(props: Props) {
             </CopyButton>
 
             <CopyButton
-              value={`${process.env.NEXT_PUBLIC_APP_URL}/url?id=${props.cardContent.url}`}
+              value={`${process.env.NEXT_PUBLIC_APP_URL}${getSembleHref(props.cardContent.url)}`}
             >
               {({ copy }) => (
                 <Menu.Item

--- a/src/webapp/features/cards/lib/mutations/useAddCard.tsx
+++ b/src/webapp/features/cards/lib/mutations/useAddCard.tsx
@@ -20,6 +20,7 @@ import { notifications } from '@mantine/notifications';
 import { Button, Group, Text } from '@mantine/core';
 import { BsCheck, BsExclamation } from 'react-icons/bs';
 import { useRouter } from 'next/navigation';
+import { getSembleHref } from '@/lib/utils/link';
 
 export default function useAddCard(
   analyticsContext?: CardSaveAnalyticsContext,
@@ -69,7 +70,7 @@ export default function useAddCard(
                 color="gray"
                 onClick={() => {
                   notifications.hide(notificationId);
-                  router.push(`/url?id=${encodeURIComponent(variables.url)}`);
+                  router.push(getSembleHref(variables.url));
                 }}
               >
                 View

--- a/src/webapp/features/collections/containers/collectionEmbedContainer/CollectionEmbedContainer.tsx
+++ b/src/webapp/features/collections/containers/collectionEmbedContainer/CollectionEmbedContainer.tsx
@@ -16,7 +16,11 @@ import {
 import SembleLogo from '@/assets/semble-logo.svg';
 import { RiArrowRightUpLine } from 'react-icons/ri';
 import UrlCardContent from '@/features/cards/components/urlCardContent/UrlCardContent';
-import { isCollectionPage, isProfilePage } from '@/lib/utils/link';
+import {
+  getSembleHref,
+  isCollectionPage,
+  isProfilePage,
+} from '@/lib/utils/link';
 import useCollection from '../../lib/queries/useCollection';
 import { Fragment } from 'react';
 import InfiniteScroll from '@/components/contentDisplay/infiniteScroll/InfiniteScroll';
@@ -151,7 +155,7 @@ export default function CollectionEmbedContainer(props: Props) {
                           return;
                         }
 
-                        router.push(`/url?id=${card.cardContent.url}`);
+                        router.push(getSembleHref(card.cardContent.url));
                       }}
                     >
                       <Stack justify="space-between" gap={'sm'} flex={1}>

--- a/src/webapp/features/collections/containers/collectionGalleryEmbedContainer/CollectionGalleryEmbedContainer.tsx
+++ b/src/webapp/features/collections/containers/collectionGalleryEmbedContainer/CollectionGalleryEmbedContainer.tsx
@@ -16,7 +16,11 @@ import {
 } from '@mantine/core';
 import SembleLogo from '@/assets/semble-logo.svg';
 import UrlCardContent from '@/features/cards/components/urlCardContent/UrlCardContent';
-import { isCollectionPage, isProfilePage } from '@/lib/utils/link';
+import {
+  getSembleHref,
+  isCollectionPage,
+  isProfilePage,
+} from '@/lib/utils/link';
 import useCollection from '../../lib/queries/useCollection';
 import { useRouter } from 'next/navigation';
 import { useState } from 'react';
@@ -184,7 +188,7 @@ function CollectionGalleryContent(props: Props) {
                       return;
                     }
 
-                    router.push(`/url?id=${currentCard.cardContent.url}`);
+                    router.push(getSembleHref(currentCard.cardContent.url));
                   }}
                 >
                   <Stack justify="space-between" gap={'xs'} flex={1}>

--- a/src/webapp/features/graph/components/graphView/GraphView.tsx
+++ b/src/webapp/features/graph/components/graphView/GraphView.tsx
@@ -24,6 +24,7 @@ import NodePopupDetail from '../nodePopups/NodePopupDetail';
 import GraphFilterPanel from './GraphFilterPanel';
 import { useRouter } from 'next/navigation';
 import styles from './GraphView.module.css';
+import { getSembleHref } from '@/lib/utils/link';
 
 // Dynamically import ForceGraph2D to avoid SSR issues
 const ForceGraph2D = dynamic(() => import('react-force-graph-2d'), {
@@ -287,10 +288,10 @@ export default function GraphView() {
           route = `/collections/${node.metadata.handle}/${node.metadata.rkey}`;
           break;
         case 'URL':
-          route = `/url?id=${encodeURIComponent(node.metadata.url)}`;
+          route = getSembleHref(node.metadata.url);
           break;
         case 'NOTE':
-          route = `/url?id=${encodeURIComponent(node.metadata.parentUrl)}`;
+          route = getSembleHref(node.metadata.parentUrl);
           break;
         default:
           return;

--- a/src/webapp/features/graph/components/graphView/UrlGraphView.tsx
+++ b/src/webapp/features/graph/components/graphView/UrlGraphView.tsx
@@ -24,6 +24,7 @@ import NodePopupDetail from '../nodePopups/NodePopupDetail';
 import GraphFilterPanel from './GraphFilterPanel';
 import { useRouter } from 'next/navigation';
 import styles from './GraphView.module.css';
+import { getSembleHref } from '@/lib/utils/link';
 
 // Dynamically import ForceGraph2D to avoid SSR issues
 const ForceGraph2D = dynamic(() => import('react-force-graph-2d'), {
@@ -230,10 +231,10 @@ export default function UrlGraphView({ url }: UrlGraphViewProps) {
           route = `/collections/${node.metadata.handle}/${node.metadata.rkey}`;
           break;
         case 'URL':
-          route = `/url?id=${encodeURIComponent(node.metadata.url)}`;
+          route = getSembleHref(node.metadata.url);
           break;
         case 'NOTE':
-          route = `/url?id=${encodeURIComponent(node.metadata.parentUrl)}`;
+          route = getSembleHref(node.metadata.parentUrl);
           break;
         default:
           return;

--- a/src/webapp/features/graph/components/graphView/UserGraphView.tsx
+++ b/src/webapp/features/graph/components/graphView/UserGraphView.tsx
@@ -24,6 +24,7 @@ import NodePopupDetail from '../nodePopups/NodePopupDetail';
 import GraphFilterPanel from './GraphFilterPanel';
 import { useRouter } from 'next/navigation';
 import styles from './GraphView.module.css';
+import { getSembleHref } from '@/lib/utils/link';
 
 // Dynamically import ForceGraph2D to avoid SSR issues
 const ForceGraph2D = dynamic(() => import('react-force-graph-2d'), {
@@ -291,10 +292,10 @@ export default function UserGraphView({ identifier }: UserGraphViewProps) {
           route = `/collections/${node.metadata.handle}/${node.metadata.rkey}`;
           break;
         case 'URL':
-          route = `/url?id=${encodeURIComponent(node.metadata.url)}`;
+          route = getSembleHref(node.metadata.url);
           break;
         case 'NOTE':
-          route = `/url?id=${encodeURIComponent(node.metadata.parentUrl)}`;
+          route = getSembleHref(node.metadata.parentUrl);
           break;
         default:
           return;

--- a/src/webapp/features/platforms/bluesky/components/blueskyMentionPost/BlueskyMentionPost.tsx
+++ b/src/webapp/features/platforms/bluesky/components/blueskyMentionPost/BlueskyMentionPost.tsx
@@ -18,6 +18,7 @@ import { AppBskyFeedPost } from '@atproto/api';
 import { useRouter } from 'next/navigation';
 import { MouseEvent } from 'react';
 import { getPostRkeyFromUri } from '../../lib/utils/link';
+import { getSembleHref } from '@/lib/utils/link';
 
 interface Props {
   post: PostView;
@@ -31,7 +32,9 @@ export default function BlueskyMentionPost(props: Props) {
     e.stopPropagation();
 
     router.push(
-      `/url?id=https://bsky.app/profile/${props.post.author.did}/post/${getPostRkeyFromUri(props.post.uri)}`,
+      getSembleHref(
+        `https://bsky.app/profile/${props.post.author.did}/post/${getPostRkeyFromUri(props.post.uri)}`,
+      ),
     );
   };
 

--- a/src/webapp/features/reader/components/ReaderHeaderButton/ReaderHeaderButton.tsx
+++ b/src/webapp/features/reader/components/ReaderHeaderButton/ReaderHeaderButton.tsx
@@ -7,11 +7,9 @@ import ReaderButton from '../ReaderButton/ReaderButton';
 export default function ReaderHeaderButton() {
   const { data: featureFlags } = useFeatureFlags();
   const searchParams = useSearchParams();
-  const rawId = searchParams.get('id');
+  const url = searchParams.get('id');
 
-  if (!featureFlags?.readerMode || !rawId) return null;
-
-  const url = decodeURIComponent(rawId);
+  if (!featureFlags?.readerMode || !url) return null;
 
   // Key is used to reset reader state across /url navigations
   return <ReaderButton key={url} url={url} />;

--- a/src/webapp/features/semble/components/ShareHeaderButton/ShareHeaderButton.tsx
+++ b/src/webapp/features/semble/components/ShareHeaderButton/ShareHeaderButton.tsx
@@ -4,6 +4,7 @@ import { ActionIcon, CopyButton, Tooltip } from '@mantine/core';
 import { notifications } from '@mantine/notifications';
 import { useSearchParams } from 'next/navigation';
 import { MdIosShare } from 'react-icons/md';
+import { getSembleHref } from '@/lib/utils/link';
 
 export default function ShareHeaderButton() {
   const searchParams = useSearchParams();
@@ -11,7 +12,7 @@ export default function ShareHeaderButton() {
 
   if (!rawId) return null;
 
-  const shareLink = `${process.env.NEXT_PUBLIC_APP_URL}/url?id=${rawId}`;
+  const shareLink = `${process.env.NEXT_PUBLIC_APP_URL}${getSembleHref(rawId)}`;
 
   return (
     <CopyButton value={shareLink}>

--- a/src/webapp/features/semble/components/sembleStats/SembleStatItem.tsx
+++ b/src/webapp/features/semble/components/sembleStats/SembleStatItem.tsx
@@ -2,6 +2,7 @@
 
 import { UnstyledButton } from '@mantine/core';
 import { ReactNode } from 'react';
+import { buildSembleQuery } from '@/lib/utils/link';
 
 export const SEMBLE_TAB_CHANGE_EVENT = 'semble:tab-change';
 
@@ -15,20 +16,11 @@ interface Props {
 export default function SembleStatItem(props: Props) {
   const handleClick = () => {
     const params = new URLSearchParams(window.location.search);
-    const queryParts: string[] = [];
-    let foundTab = false;
-    params.forEach((value, key) => {
-      if (key === 'sembleTab') {
-        queryParts.push(`sembleTab=${props.tab}`);
-        foundTab = true;
-      } else {
-        queryParts.push(`${key}=${value}`);
-      }
-    });
-    if (!foundTab) {
-      queryParts.push(`sembleTab=${props.tab}`);
-    }
-    window.history.replaceState(null, '', `?${queryParts.join('&')}`);
+    window.history.replaceState(
+      null,
+      '',
+      buildSembleQuery(params, { set: { sembleTab: props.tab } }),
+    );
     window.dispatchEvent(
       new CustomEvent<SembleStatTab>(SEMBLE_TAB_CHANGE_EVENT, {
         detail: props.tab,

--- a/src/webapp/features/semble/components/sembleTabs/SembleTabs.tsx
+++ b/src/webapp/features/semble/components/sembleTabs/SembleTabs.tsx
@@ -2,6 +2,7 @@
 
 import { useState, Suspense, useEffect } from 'react';
 import { useSearchParams } from 'next/navigation';
+import { encodeUrlParam } from '@/lib/utils/link';
 import { SEMBLE_TAB_CHANGE_EVENT } from '../sembleStats/SembleStatItem';
 import {
   Box,
@@ -92,7 +93,7 @@ export default function SembleTabs(props: Props) {
         const newTab = val as TabValue;
         setActiveTab(newTab);
         const viaCardId = searchParams.get('viaCardId');
-        const qs = `id=${props.url}&sembleTab=${newTab}${viaCardId ? `&viaCardId=${viaCardId}` : ''}`;
+        const qs = `id=${encodeUrlParam(props.url)}&sembleTab=${newTab}${viaCardId ? `&viaCardId=${viaCardId}` : ''}`;
         window.history.replaceState(null, '', `?${qs}`);
       }}
     >

--- a/src/webapp/features/semble/containers/sembleContainer/SemblePageClient.tsx
+++ b/src/webapp/features/semble/containers/sembleContainer/SemblePageClient.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useRef, useEffect } from 'react';
+import { buildSembleQuery } from '@/lib/utils/link';
 
 interface Props {
   viaCardId?: string;
@@ -17,15 +18,12 @@ export default function SemblePageClient(props: Props) {
   // Clean URL on mount if viaCardId exists
   useEffect(() => {
     if (props.viaCardId && !cleanedUrlRef.current) {
-      // Manually build query string to avoid re-encoding the URL
       const params = new URLSearchParams(window.location.search);
-      const queryParts: string[] = [];
-      params.forEach((value, key) => {
-        if (key !== 'viaCardId') {
-          queryParts.push(`${key}=${value}`);
-        }
-      });
-      window.history.replaceState(null, '', `?${queryParts.join('&')}`);
+      window.history.replaceState(
+        null,
+        '',
+        buildSembleQuery(params, { omit: 'viaCardId' }),
+      );
       cleanedUrlRef.current = true;
     }
   }, [props.viaCardId]);

--- a/src/webapp/features/semble/containers/sembleContainer/UrlParamCleaner.tsx
+++ b/src/webapp/features/semble/containers/sembleContainer/UrlParamCleaner.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect } from 'react';
 import { useSearchParams, useRouter } from 'next/navigation';
+import { buildSembleQuery } from '@/lib/utils/link';
 
 interface Props {
   paramToRemove: string;
@@ -17,14 +18,12 @@ export default function UrlParamCleaner(props: Props) {
   useEffect(() => {
     const paramValue = searchParams.get(props.paramToRemove);
     if (paramValue) {
-      // Manually build query string to avoid re-encoding the URL
-      const params: string[] = [];
-      searchParams.forEach((value, key) => {
-        if (key !== props.paramToRemove) {
-          params.push(`${key}=${value}`);
-        }
-      });
-      router.replace(`?${params.join('&')}`, { scroll: false });
+      router.replace(
+        buildSembleQuery(new URLSearchParams(searchParams.toString()), {
+          omit: props.paramToRemove,
+        }),
+        { scroll: false },
+      );
     }
   }, [searchParams, router, props.paramToRemove]);
 

--- a/src/webapp/features/url/containers/urlEmbedContainer/UrlEmbedContainer.tsx
+++ b/src/webapp/features/url/containers/urlEmbedContainer/UrlEmbedContainer.tsx
@@ -16,7 +16,11 @@ import { BiCollection, BiLink } from 'react-icons/bi';
 import UrlCardContent from '@/features/cards/components/urlCardContent/UrlCardContent';
 import { useUrlMetadataWithStats } from '@/features/cards/lib/queries/useUrlMetadata';
 import { useRouter } from 'next/navigation';
-import { isCollectionPage, isProfilePage } from '@/lib/utils/link';
+import {
+  getSembleHref,
+  isCollectionPage,
+  isProfilePage,
+} from '@/lib/utils/link';
 import SembleHeaderBackground from '@/features/semble/containers/sembleContainer/SembleHeaderBackground';
 import UrlEmbedContainerSkeleton from './skeleton.UrlEmbedContainer';
 import { LinkActionIcon } from '@/components/link/MantineLink';
@@ -41,7 +45,7 @@ export default function UrlEmbedContainer(props: Props) {
       router.push(props.url);
       return;
     }
-    router.push(`/url?id=${encodeURIComponent(props.url)}`);
+    router.push(getSembleHref(props.url));
   };
 
   if (isPending) {
@@ -66,7 +70,7 @@ export default function UrlEmbedContainer(props: Props) {
             size="compact-xs"
             variant="transparent"
             radius={'xs'}
-            href={`${appUrl}/url?id=${encodeURIComponent(props.url)}`}
+            href={`${appUrl}${getSembleHref(props.url)}`}
             target="_blank"
           >
             <Image src={SembleLogo.src} alt="Semble" h={24} />

--- a/src/webapp/lib/utils/link.ts
+++ b/src/webapp/lib/utils/link.ts
@@ -26,6 +26,46 @@ export const getDisplayUrl = (url: string, maxPathLength = Infinity) => {
   }
 };
 
+// Escapes only the characters that break a query-string value so `?id=<url>`
+// stays readable in the address bar. `%` must go first.
+export const encodeUrlParam = (url: string) =>
+  url.replace(/[%#&+]/g, (c) => encodeURIComponent(c));
+
+// `id` goes last since it is the only value that can contain a query string
+export const getSembleHref = (
+  url: string,
+  opts?: { viaCardId?: string; sembleTab?: string },
+) => {
+  const parts: string[] = [];
+  if (opts?.viaCardId) parts.push(`viaCardId=${opts.viaCardId}`);
+  if (opts?.sembleTab) parts.push(`sembleTab=${opts.sembleTab}`);
+  parts.push(`id=${encodeUrlParam(url)}`);
+  return `/url?${parts.join('&')}`;
+};
+
+// Rebuilds a semble page query string from already-decoded params without
+// re-encoding anything but the `id` url
+export const buildSembleQuery = (
+  params: URLSearchParams,
+  opts?: { omit?: string; set?: Record<string, string> },
+) => {
+  const parts: string[] = [];
+  const pending = { ...(opts?.set ?? {}) };
+  params.forEach((value, key) => {
+    if (key === opts?.omit) return;
+    if (key in pending) {
+      parts.push(`${key}=${pending[key]}`);
+      delete pending[key];
+      return;
+    }
+    parts.push(`${key}=${key === 'id' ? encodeUrlParam(value) : value}`);
+  });
+  for (const [key, value] of Object.entries(pending)) {
+    parts.push(`${key}=${value}`);
+  }
+  return `?${parts.join('&')}`;
+};
+
 export const getUrlFromSlug = (slug: string[]) => {
   const decoded = slug.map(decodeURIComponent);
   const url = decoded.join('/');


### PR DESCRIPTION
TLDR: Links with fragments have their own semble page now

Card clicks built `/url?id=<raw url>` with no encoding, so the browser treated a `#fragment` as the page hash and dropped it, landing on the semble page for a different URL. The same raw paste existed in the share buttons, embeds, legacy path redirect, and the in-page query rewriters for tabs and stat pills.

Add getSembleHref / encodeUrlParam / buildSembleQuery in lib/utils/link (escapes only `% # & +` so the address bar stays readable) and route every semble page link and query rewrite through them. Drop the extra decodeURIComponent on searchParams.id since Next.js already decodes it.