### PR TITLE
Resolve the current PDS for app-password authentication

### DIFF
--- a/src/modules/atproto/infrastructure/services/ATProtoAgentService.ts
+++ b/src/modules/atproto/infrastructure/services/ATProtoAgentService.ts
@@ -1,3 +1,4 @@
+import { createAppPasswordAgent } from './AppPasswordSessionService';
 import { AtpAgent, Agent } from '@atproto/api';
 import { NodeOAuthClient } from '@atproto/oauth-client-node';
 import { IdResolver } from '@atproto/identity';
@@ -177,9 +178,7 @@ export class ATProtoAgentService implements IAgentService {
       const session = appPasswordSessionResult.value;
       if (session) {
         // Create an Agent with the session
-        const agent = new AtpAgent({
-          service: ATPROTO_SERVICE_ENDPOINTS.AUTHENTICATED_BSKY_SERVICE,
-        });
+        const { agent } = await createAppPasswordAgent(did.value);
 
         // Resume the session
         await agent.resumeSession(session);
@@ -232,9 +231,7 @@ export class ATProtoAgentService implements IAgentService {
           await this.appPasswordSessionService.getSession(serviceAccountDid);
         if (existingSessionResult.isOk()) {
           const session = existingSessionResult.value;
-          const agent = new AtpAgent({
-            service: ATPROTO_SERVICE_ENDPOINTS.AUTHENTICATED_BSKY_SERVICE,
-          });
+          const { agent } = await createAppPasswordAgent(session.did);
           await agent.resumeSession(session);
           return ok(agent);
         }
@@ -256,9 +253,7 @@ export class ATProtoAgentService implements IAgentService {
       }
 
       const session = newSessionResult.value;
-      const agent = new AtpAgent({
-        service: ATPROTO_SERVICE_ENDPOINTS.AUTHENTICATED_BSKY_SERVICE,
-      });
+      const { agent } = await createAppPasswordAgent(session.did);
       await agent.resumeSession(session);
 
       return ok(agent);

--- a/src/modules/atproto/infrastructure/services/ATProtoAgentService.ts
+++ b/src/modules/atproto/infrastructure/services/ATProtoAgentService.ts
@@ -1,4 +1,4 @@
-import { createAppPasswordAgent } from './AppPasswordSessionService';
+import { createPdsAgent } from './PdsAgent';
 import { AtpAgent, Agent } from '@atproto/api';
 import { NodeOAuthClient } from '@atproto/oauth-client-node';
 import { IdResolver } from '@atproto/identity';
@@ -178,7 +178,7 @@ export class ATProtoAgentService implements IAgentService {
       const session = appPasswordSessionResult.value;
       if (session) {
         // Create an Agent with the session
-        const { agent } = await createAppPasswordAgent(did.value);
+        const { agent } = await createPdsAgent(did.value);
 
         // Resume the session
         await agent.resumeSession(session);
@@ -231,7 +231,7 @@ export class ATProtoAgentService implements IAgentService {
           await this.appPasswordSessionService.getSession(serviceAccountDid);
         if (existingSessionResult.isOk()) {
           const session = existingSessionResult.value;
-          const { agent } = await createAppPasswordAgent(session.did);
+          const { agent } = await createPdsAgent(session.did);
           await agent.resumeSession(session);
           return ok(agent);
         }
@@ -253,7 +253,7 @@ export class ATProtoAgentService implements IAgentService {
       }
 
       const session = newSessionResult.value;
-      const { agent } = await createAppPasswordAgent(session.did);
+      const { agent } = await createPdsAgent(session.did);
       await agent.resumeSession(session);
 
       return ok(agent);

--- a/src/modules/atproto/infrastructure/services/AppPasswordSessionService.ts
+++ b/src/modules/atproto/infrastructure/services/AppPasswordSessionService.ts
@@ -1,33 +1,13 @@
 import { err, ok, Result } from 'src/shared/core/Result';
 import { IAppPasswordSessionRepository } from '../repositories/IAppPasswordSessionRepository';
-import { AtpAgent, AtpSessionData } from '@atproto/api';
+import { AtpSessionData } from '@atproto/api';
 import { IAppPasswordSessionService } from '../../application/IAppPasswordSessionService';
-import { IdResolver } from '@atproto/identity';
-
-export async function createAppPasswordAgent(identifier: string) {
-  const resolver = new IdResolver();
-  const did = identifier.startsWith('did:')
-    ? identifier
-    : await resolver.handle.resolve(identifier);
-  if (!did) throw new Error('Could not resolve account handle');
-  const identity = await resolver.did.resolveAtprotoData(did);
-  const endpoint = new URL(identity.pds);
-  if (
-    endpoint.protocol !== 'https:' ||
-    endpoint.username ||
-    endpoint.password
-  ) {
-    throw new Error(
-      'Account PDS must be an HTTPS endpoint without credentials',
-    );
-  }
-  return { did, agent: new AtpAgent({ service: endpoint }) };
-}
+import { createPdsAgent } from './PdsAgent';
 
 export class AppPasswordSessionService implements IAppPasswordSessionService {
   constructor(
     private readonly appPasswordSessionRepository: IAppPasswordSessionRepository,
-    private readonly createAgent = createAppPasswordAgent,
+    private readonly createAgent = createPdsAgent,
   ) {}
   async getSession(did: string): Promise<Result<AtpSessionData>> {
     const sessionResult =

--- a/src/modules/atproto/infrastructure/services/AppPasswordSessionService.ts
+++ b/src/modules/atproto/infrastructure/services/AppPasswordSessionService.ts
@@ -2,11 +2,32 @@ import { err, ok, Result } from 'src/shared/core/Result';
 import { IAppPasswordSessionRepository } from '../repositories/IAppPasswordSessionRepository';
 import { AtpAgent, AtpSessionData } from '@atproto/api';
 import { IAppPasswordSessionService } from '../../application/IAppPasswordSessionService';
-import { ATPROTO_SERVICE_ENDPOINTS } from './ServiceEndpoints';
+import { IdResolver } from '@atproto/identity';
+
+export async function createAppPasswordAgent(identifier: string) {
+  const resolver = new IdResolver();
+  const did = identifier.startsWith('did:')
+    ? identifier
+    : await resolver.handle.resolve(identifier);
+  if (!did) throw new Error('Could not resolve account handle');
+  const identity = await resolver.did.resolveAtprotoData(did);
+  const endpoint = new URL(identity.pds);
+  if (
+    endpoint.protocol !== 'https:' ||
+    endpoint.username ||
+    endpoint.password
+  ) {
+    throw new Error(
+      'Account PDS must be an HTTPS endpoint without credentials',
+    );
+  }
+  return { did, agent: new AtpAgent({ service: endpoint }) };
+}
 
 export class AppPasswordSessionService implements IAppPasswordSessionService {
   constructor(
     private readonly appPasswordSessionRepository: IAppPasswordSessionRepository,
+    private readonly createAgent = createAppPasswordAgent,
   ) {}
   async getSession(did: string): Promise<Result<AtpSessionData>> {
     const sessionResult =
@@ -14,29 +35,38 @@ export class AppPasswordSessionService implements IAppPasswordSessionService {
     if (sessionResult.isErr()) {
       return err(sessionResult.error);
     }
-    const agent = new AtpAgent({
-      service: ATPROTO_SERVICE_ENDPOINTS.AUTHENTICATED_BSKY_SERVICE,
-    });
-
     const sessionWithAppPassword = sessionResult.value;
     if (!sessionWithAppPassword) {
       return err(new Error(`No session found for DID: ${did}`));
     }
     try {
-      await agent.resumeSession(sessionResult.value.session);
+      const { agent } = await this.createAgent(did);
+      await agent.resumeSession(sessionWithAppPassword.session);
       const session = agent.session;
-      if (!session) {
-        return err(new Error(`Failed to resume session for DID: ${did}`));
+      if (!session || session.did !== did || !session.active) {
+        throw new Error(
+          'Restored session does not belong to an active target account',
+        );
       }
+      const saved = await this.appPasswordSessionRepository.saveSession(did, {
+        session,
+        appPassword: sessionWithAppPassword.appPassword,
+      });
+      if (saved.isErr()) return err(saved.error);
       return ok(session);
     } catch (error) {
       try {
+        const { agent } = await this.createAgent(did);
         await agent.login({
           identifier: sessionWithAppPassword.session.did,
           password: sessionWithAppPassword.appPassword,
         });
         const updatedSession = agent.session;
-        if (!updatedSession) {
+        if (
+          !updatedSession ||
+          updatedSession.did !== did ||
+          !updatedSession.active
+        ) {
           return err(
             new Error(`Failed to login with app password for DID: ${did}`),
           );
@@ -71,19 +101,18 @@ export class AppPasswordSessionService implements IAppPasswordSessionService {
     identifier: string,
     appPassword: string,
   ): Promise<Result<AtpSessionData>> {
-    const agent = new AtpAgent({
-      service: ATPROTO_SERVICE_ENDPOINTS.AUTHENTICATED_BSKY_SERVICE,
-    });
-
     try {
+      const { did, agent } = await this.createAgent(identifier);
       await agent.login({
-        identifier,
+        identifier: did,
         password: appPassword,
       });
       const session = agent.session;
-      if (!session) {
+      if (!session || session.did !== did || !session.active) {
         return err(
-          new Error(`Failed to create session for identifier: ${identifier}`),
+          new Error(
+            `Failed to create an active session for identifier: ${identifier}`,
+          ),
         );
       }
       const saveResult = await this.appPasswordSessionRepository.saveSession(

--- a/src/modules/atproto/infrastructure/services/PdsAgent.ts
+++ b/src/modules/atproto/infrastructure/services/PdsAgent.ts
@@ -1,0 +1,22 @@
+import { AtpAgent } from '@atproto/api';
+import { IdResolver } from '@atproto/identity';
+
+export async function createPdsAgent(identifier: string) {
+  const resolver = new IdResolver();
+  const did = identifier.startsWith('did:')
+    ? identifier
+    : await resolver.handle.resolve(identifier);
+  if (!did) throw new Error('Could not resolve account handle');
+  const identity = await resolver.did.resolveAtprotoData(did);
+  const endpoint = new URL(identity.pds);
+  if (
+    endpoint.protocol !== 'https:' ||
+    endpoint.username ||
+    endpoint.password
+  ) {
+    throw new Error(
+      'Account PDS must be an HTTPS endpoint without credentials',
+    );
+  }
+  return { did, agent: new AtpAgent({ service: endpoint }) };
+}

--- a/src/modules/atproto/tests/infrastructure/AppPasswordSessionService.test.ts
+++ b/src/modules/atproto/tests/infrastructure/AppPasswordSessionService.test.ts
@@ -1,0 +1,129 @@
+import { AtpAgent, AtpSessionData } from '@atproto/api';
+import { AppPasswordSessionService } from '../../infrastructure/services/AppPasswordSessionService';
+import { InMemoryAppPasswordSessionRepository } from './InMemoryAppPasswordSessionRepository';
+
+const did = 'did:plc:b64lsctzqnzpv6vd4ry3qktw';
+const currentPds = 'https://current-pds.example';
+const session: AtpSessionData = {
+  did,
+  handle: 'example.test',
+  active: true,
+  accessJwt: 'access-token',
+  refreshJwt: 'refresh-token',
+};
+const didDoc = {
+  id: did,
+  service: [
+    {
+      id: '#atproto_pds',
+      type: 'AtprotoPersonalDataServer',
+      serviceEndpoint: currentPds,
+    },
+  ],
+};
+
+function fixture({ inactive = false, rejectStored = false } = {}) {
+  const repository = InMemoryAppPasswordSessionRepository.getInstance();
+  repository.clear();
+  const requests: string[] = [];
+  const identifiers: string[] = [];
+  const fetcher: typeof fetch = async (input) => {
+    const url = new URL(
+      input instanceof Request ? input.url : input.toString(),
+    );
+    requests.push(url.href);
+    if (url.origin !== currentPds)
+      throw new Error('Credential request sent to wrong PDS');
+    if (rejectStored && !url.pathname.endsWith('createSession')) {
+      return new Response(
+        JSON.stringify({
+          error: 'InvalidToken',
+          message: 'Token belongs to the old PDS',
+        }),
+        {
+          status: 401,
+          headers: { 'content-type': 'application/json' },
+        },
+      );
+    }
+    return new Response(
+      JSON.stringify({ ...session, active: !inactive, didDoc }),
+      {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      },
+    );
+  };
+  const factory = async (identifier: string) => {
+    identifiers.push(identifier);
+    return {
+      did,
+      agent: new AtpAgent({ service: currentPds, fetch: fetcher }),
+    };
+  };
+  return {
+    repository,
+    requests,
+    identifiers,
+    service: new AppPasswordSessionService(repository, factory),
+  };
+}
+
+describe('app-password sessions follow the current PDS', () => {
+  it('logs in through the resolved PDS and stores an active session', async () => {
+    const f = fixture();
+    const result = await f.service.createSession(
+      'example.test',
+      'test-password',
+    );
+    expect(result.isOk()).toBe(true);
+    expect(f.identifiers).toEqual(['example.test']);
+    expect(f.requests).toEqual([
+      `${currentPds}/xrpc/com.atproto.server.createSession`,
+    ]);
+    expect(f.repository.size()).toBe(1);
+  });
+  it('does not mistake a successful inactive-account login for usable authentication', async () => {
+    const f = fixture({ inactive: true });
+    expect(
+      (await f.service.createSession('example.test', 'test-password')).isErr(),
+    ).toBe(true);
+    expect(f.repository.size()).toBe(0);
+  });
+  it('restores at the current PDS instead of the fixed Bluesky service', async () => {
+    const f = fixture();
+    await f.repository.saveSession(did, {
+      session,
+      appPassword: 'test-password',
+    });
+    expect((await f.service.getSession(did)).isOk()).toBe(true);
+    expect(f.requests).toEqual([
+      `${currentPds}/xrpc/com.atproto.server.getSession`,
+    ]);
+  });
+  it('re-authenticates on the current PDS when persisted old-PDS tokens are rejected', async () => {
+    const f = fixture({ rejectStored: true });
+    await f.repository.saveSession(did, {
+      session,
+      appPassword: 'test-password',
+    });
+    expect((await f.service.getSession(did)).isOk()).toBe(true);
+    expect(f.requests.at(-1)).toBe(
+      `${currentPds}/xrpc/com.atproto.server.createSession`,
+    );
+    expect(f.requests.every((request) => request.startsWith(currentPds))).toBe(
+      true,
+    );
+  });
+  it('does not silently fall back to Bluesky when identity resolution fails', async () => {
+    const f = fixture();
+    const service = new AppPasswordSessionService(f.repository, async () => {
+      throw new Error('DID resolution failed');
+    });
+    expect(
+      (await service.createSession('example.test', 'test-password')).isErr(),
+    ).toBe(true);
+    expect(f.repository.size()).toBe(0);
+    expect(f.requests).toEqual([]);
+  });
+});


### PR DESCRIPTION
App-password login can succeed against an account's old PDS after migration, then fail to publish with `Account is deactivated`. This fixes login and session restoration to use the current PDS from the account's DID document instead of always starting at `bsky.social`.

Reproduced with `bufo.uk`: the same credentials authenticate an inactive account through `bsky.social` and an active account at its current PDS, `pds.zat.dev`. Semble accepted the former session and failed on the subsequent write.

The change also checks session identity and active status, persists refreshed sessions, and resolves the PDS again when constructing publishing and service-account agents. Fixing initial login alone is insufficient: the SDK's persisted `AtpSessionData` does not retain the service endpoint.

<details>
<summary>Validation</summary>

- Nine tests pass across `AppPasswordSessionService.test.ts` and the existing `ATProtoAgentService.test.ts`. The new tests exercise real `AtpAgent` instances with supplied HTTP responses, covering current-PDS login/restoration, recovery from rejected old-PDS tokens, inactive accounts, and resolution failures.
- Live test of the patched path: login, stored-session restoration, publisher restoration, and a temporary Semble collection write succeeded on `pds.zat.dev`. The collection was deleted, and a follow-up read returned `RecordNotFound`.
- `git diff --check` passes.
- `npm run build:check` reports three errors in `OAuthClientFactory.ts` and `MetadataWorkerProcess.ts`. The unchanged baseline reproduces all three with the same dependencies. Workspace types/contracts were built first. The upstream lockfile also prevented `npm ci`; local dependencies were installed without changing the lockfile.

</details>

This draft changes app-password authentication only. Related historical PRs #798 (closed) and #925 (merged) concern OAuth configuration/session handling, not this path. No database migration or PDS deployment is required.

![bufo entrance](https://all-the.bufo.zone/bufo-entrance.gif)

generated with Codex (GPT-6)
